### PR TITLE
feat(m2): structured event schema + emitter + extractor

### DIFF
--- a/argus_events.py
+++ b/argus_events.py
@@ -63,9 +63,11 @@ class EventEmitter:
         if self._ready is not None:
             return self._ready
         try:
-            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+            dirpath = os.path.dirname(self._path)
+            if dirpath:
+                os.makedirs(dirpath, exist_ok=True)
             self._ready = True
-        except OSError as e:
+        except Exception as e:
             print(f"[Argus Events] Cannot create sink directory: {e}")
             self._ready = False
         return self._ready

--- a/argus_events.py
+++ b/argus_events.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 from dataclasses import dataclass, asdict, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -58,6 +59,7 @@ class EventEmitter:
     def __init__(self, sink_path: Optional[str] = None):
         self._path = sink_path or os.environ.get("ARGUS_EVENTS_PATH", _DEFAULT_SINK)
         self._ready: Optional[bool] = None  # lazy init
+        self._lock = threading.Lock()  # guards concurrent file appends
 
     def _ensure_sink(self) -> bool:
         if self._ready is not None:
@@ -92,8 +94,9 @@ class EventEmitter:
             payload=payload_kwargs,
         )
         try:
-            with open(self._path, "a", encoding="utf-8") as fh:
-                fh.write(json.dumps(event.to_dict()) + "\n")
+            with self._lock:
+                with open(self._path, "a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(event.to_dict()) + "\n")
         except Exception as e:
             print(f"[Argus Events] Emit failed: {e}")
 

--- a/argus_events.py
+++ b/argus_events.py
@@ -1,0 +1,100 @@
+"""
+Argus structured event schema and emitter.
+
+Writes machine-readable events to a jsonlines sink independently of the
+existing print-based log, so neither the existing log format nor the
+PR-Agent pipeline is affected.
+
+Sink path: $ARGUS_EVENTS_PATH (default: /var/log/argus/events.jsonl)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+
+class EventType(str, Enum):
+    REVIEW_STARTED = "review_started"
+    FINDING_POSTED = "finding_posted"
+    REPLY_CLASSIFIED = "reply_classified"
+    THREAD_RESOLVED = "thread_resolved"
+    ERROR = "error"
+    MENTION_REWRITTEN = "mention_rewritten"
+    REQUEST_BLOCKED = "request_blocked"
+
+
+@dataclass
+class ArgusEvent:
+    event_type: EventType
+    timestamp: str
+    pr_number: Optional[int] = None
+    repo: Optional[str] = None
+    severity: Optional[str] = None  # Critical | Major | Medium | Minor | None
+    payload: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["event_type"] = self.event_type.value
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ArgusEvent":
+        d = dict(d)
+        d["event_type"] = EventType(d["event_type"])
+        return cls(**d)
+
+
+_DEFAULT_SINK = "/var/log/argus/events.jsonl"
+
+
+class EventEmitter:
+    """Writes ArgusEvent records as jsonlines to a configurable sink file."""
+
+    def __init__(self, sink_path: Optional[str] = None):
+        self._path = sink_path or os.environ.get("ARGUS_EVENTS_PATH", _DEFAULT_SINK)
+        self._ready: Optional[bool] = None  # lazy init
+
+    def _ensure_sink(self) -> bool:
+        if self._ready is not None:
+            return self._ready
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+            self._ready = True
+        except OSError as e:
+            print(f"[Argus Events] Cannot create sink directory: {e}")
+            self._ready = False
+        return self._ready
+
+    def emit(
+        self,
+        event_type: EventType,
+        pr_number: Optional[int] = None,
+        repo: Optional[str] = None,
+        severity: Optional[str] = None,
+        **payload_kwargs: Any,
+    ) -> None:
+        """Emit a structured event. Never raises — errors are print-logged only."""
+        if not self._ensure_sink():
+            return
+        event = ArgusEvent(
+            event_type=event_type,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            pr_number=pr_number,
+            repo=repo,
+            severity=severity,
+            payload=payload_kwargs,
+        )
+        try:
+            with open(self._path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event.to_dict()) + "\n")
+        except Exception as e:
+            print(f"[Argus Events] Emit failed: {e}")
+
+
+# Module-level singleton — imported by entrypoint-guard and patch_suggestion_format
+emitter = EventEmitter()

--- a/argus_extractor.py
+++ b/argus_extractor.py
@@ -1,0 +1,72 @@
+"""
+Argus event extractor.
+
+Reads events from the jsonlines sink and returns a filtered list of
+ArgusEvent objects. Supports optional time-range and event-type filtering.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from argus_events import ArgusEvent, EventType
+
+_DEFAULT_SINK = "/var/log/argus/events.jsonl"
+
+
+def read_events(
+    sink_path: Optional[str] = None,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    event_types: Optional[List[EventType]] = None,
+) -> List[ArgusEvent]:
+    """Read events from the jsonlines sink.
+
+    Args:
+        sink_path: Path to the events.jsonl file. Defaults to
+            $ARGUS_EVENTS_PATH or /var/log/argus/events.jsonl.
+        since: Include only events at or after this timestamp (UTC-aware).
+        until: Include only events at or before this timestamp (UTC-aware).
+        event_types: Whitelist of EventType values to include. None = all.
+
+    Returns:
+        List of ArgusEvent objects matching the filters, in file order.
+    """
+    path = sink_path or os.environ.get("ARGUS_EVENTS_PATH", _DEFAULT_SINK)
+    if not os.path.exists(path):
+        return []
+
+    events: List[ArgusEvent] = []
+    with open(path, encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                raw = json.loads(line)
+                event = ArgusEvent.from_dict(raw)
+            except Exception as e:
+                print(f"[Argus Extractor] Skipping malformed line {lineno}: {e}")
+                continue
+
+            if event_types is not None and event.event_type not in event_types:
+                continue
+
+            if since is not None or until is not None:
+                try:
+                    ts = datetime.fromisoformat(event.timestamp)
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    if since is not None and ts < since:
+                        continue
+                    if until is not None and ts > until:
+                        continue
+                except ValueError:
+                    pass  # unparseable timestamp — include anyway
+
+            events.append(event)
+
+    return events

--- a/argus_extractor.py
+++ b/argus_extractor.py
@@ -64,8 +64,8 @@ def read_events(
                         continue
                     if until is not None and ts > until:
                         continue
-                except ValueError:
-                    pass  # unparseable timestamp — include anyway
+                except (ValueError, TypeError):
+                    pass  # unparseable or tz-incompatible timestamp — include anyway
 
             events.append(event)
 

--- a/argus_extractor.py
+++ b/argus_extractor.py
@@ -40,7 +40,12 @@ def read_events(
         return []
 
     events: List[ArgusEvent] = []
-    with open(path, encoding="utf-8") as fh:
+    try:
+        fh = open(path, encoding="utf-8")
+    except OSError as e:
+        print(f"[Argus Extractor] Cannot open sink: {e}")
+        return events
+    with fh:
         for lineno, line in enumerate(fh, 1):
             line = line.strip()
             if not line:

--- a/argus_extractor.py
+++ b/argus_extractor.py
@@ -56,16 +56,19 @@ def read_events(
                 continue
 
             if since is not None or until is not None:
+                # Normalize caller's datetimes to UTC-aware to prevent TypeError
+                _since = since.replace(tzinfo=timezone.utc) if since is not None and since.tzinfo is None else since
+                _until = until.replace(tzinfo=timezone.utc) if until is not None and until.tzinfo is None else until
                 try:
                     ts = datetime.fromisoformat(event.timestamp)
                     if ts.tzinfo is None:
                         ts = ts.replace(tzinfo=timezone.utc)
-                    if since is not None and ts < since:
+                    if _since is not None and ts < _since:
                         continue
-                    if until is not None and ts > until:
+                    if _until is not None and ts > _until:
                         continue
                 except (ValueError, TypeError):
-                    pass  # unparseable or tz-incompatible timestamp — include anyway
+                    pass  # unparseable timestamp — include anyway
 
             events.append(event)
 

--- a/entrypoint-guard.py
+++ b/entrypoint-guard.py
@@ -14,6 +14,8 @@ import json
 import os
 import re
 
+from argus_events import emitter, EventType
+
 _raw = os.environ.get("ARGUS_ALLOWED_USERS", "").strip()
 ALLOWED_USERS: set = set()
 if _raw:
@@ -68,6 +70,7 @@ class ArgusGuardMiddleware:
         is_self_bot = actor and actor.lower() == "argus-review[bot]"
         if not is_self_bot and actor and actor.lower() not in ALLOWED_USERS:
             print(f"[Argus Guard] BLOCKED: '{actor}' not in whitelist")
+            emitter.emit(EventType.REQUEST_BLOCKED, actor=actor)
             resp = json.dumps({"status": "skipped", "reason": f"user '{actor}' not in whitelist"}).encode()
             await send({"type": "http.response.start", "status": 200,
                         "headers": [[b"content-type", b"application/json"],
@@ -192,6 +195,8 @@ def _handle_reply_to_argus(body, sender):
         token = _get_app_installation_token()
         if not token:
             print("[Argus] No app installation token — cannot reply as bot")
+            emitter.emit(EventType.ERROR, pr_number=pr_number, repo=repo_full,
+                         message="no app installation token")
             return
 
         auth_h = {"Authorization": f"Bearer {token}",
@@ -253,6 +258,8 @@ def _handle_reply_to_argus(body, sender):
 
             if argus_judgment_count >= MAX_REPLY_ROUNDS:
                 print(f"[Argus] Reply judgment: max rounds reached for {t.get('path')}")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="max_rounds_reached", thread_path=t.get("path"))
                 return
 
             # Get original finding (first Argus comment)
@@ -273,6 +280,8 @@ def _handle_reply_to_argus(body, sender):
             # Never post replies for LLM errors — log and return silently
             if verdict == "ESCALATE" and "LLM error" in reason:
                 print(f"[Argus] Reply judgment LLM failed for {thread_path}: {reason}")
+                emitter.emit(EventType.ERROR, pr_number=pr_number, repo=repo_full,
+                             message=f"LLM failed: {reason}", thread_path=thread_path)
                 return
 
             if verdict == "ACCEPT":
@@ -280,19 +289,28 @@ def _handle_reply_to_argus(body, sender):
                                  f"✅ Acknowledged — {reason}")
                 _resolve_thread(auth_h, t["id"])
                 print(f"[Argus] Reply accepted: {thread_path} → resolved")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="ACCEPT", thread_path=thread_path, reason=reason)
+                emitter.emit(EventType.THREAD_RESOLVED, pr_number=pr_number, repo=repo_full,
+                             thread_path=thread_path)
             elif verdict == "REJECT":
                 _reply_to_thread(auth_h, repo_full, pr_number, first_db_id,
                                  f"❓ Follow-up — {reason}")
                 print(f"[Argus] Reply rejected: {thread_path} → follow-up")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="REJECT", thread_path=thread_path, reason=reason)
             else:  # ESCALATE (genuine, not LLM error)
                 _reply_to_thread(auth_h, repo_full, pr_number, first_db_id,
                                  f"⚠️ Escalated — {reason}\n\n"
                                  f"*This thread requires human reviewer input.*")
                 print(f"[Argus] Reply escalated: {thread_path}")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="ESCALATE", thread_path=thread_path, reason=reason)
             return  # Only handle one thread per comment
 
     except Exception as e:
         print(f"[Argus] Reply handler error: {e}")
+        emitter.emit(EventType.ERROR, message=f"reply handler: {e}")
 
 
 def _patch_mention_handler():
@@ -330,6 +348,11 @@ def _patch_mention_handler():
                         print(f"[Argus] @mention rewritten: "
                               f"'{comment_body[:60]}' → '{rewritten[:60]}'")
                         body["comment"]["body"] = rewritten
+                        _pr_num = body.get("pull_request", {}).get("number")
+                        _repo = body.get("repository", {}).get("full_name")
+                        emitter.emit(EventType.MENTION_REWRITTEN, pr_number=_pr_num,
+                                     repo=_repo, original=comment_body[:60],
+                                     rewritten=rewritten[:60])
 
             return await original_handle(body, event, sender, sender_id,
                                          action, log_context, agent)

--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -9,6 +9,8 @@ Thread auto-resolve: resolve outdated threads after push
 Reference: CodeRabbit PR review format (2026)
 """
 
+from argus_events import emitter, EventType
+
 # ── Severity mapping ──────────────────────────────────────────────
 
 SEVERITY_MAP = {
@@ -1171,6 +1173,9 @@ def apply_patch():
             if not review_body:
                 return result
 
+            _repo = getattr(getattr(self.git_provider, 'repo', None), 'full_name', None)
+            emitter.emit(EventType.REVIEW_STARTED, pr_number=pr_number, repo=_repo)
+
             # Parse findings from prediction
             findings = []
             inline_comments = []
@@ -1372,6 +1377,8 @@ def apply_patch():
                 )
                 n = len(inline_comments)
                 print(f"[Argus] Posted {event} review ({n} inline, iteration {iteration})")
+                emitter.emit(EventType.FINDING_POSTED, pr_number=pr_number, repo=_repo,
+                             finding_count=n, review_event=event, iteration=iteration)
             except Exception as e:
                 print(f"[Argus] Unified review failed ({e}), fallback to COMMENT")
                 try:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,165 @@
+"""Tests for argus_events + argus_extractor (schema + round-trip)."""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from argus_events import ArgusEvent, EventType, EventEmitter
+from argus_extractor import read_events
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tmp_sink(tmp_path):
+    return str(tmp_path / "events.jsonl")
+
+
+@pytest.fixture
+def emitter(tmp_sink):
+    return EventEmitter(sink_path=tmp_sink)
+
+
+def _make_event(event_type: EventType, **kwargs) -> ArgusEvent:
+    return ArgusEvent(
+        event_type=event_type,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        pr_number=kwargs.get("pr_number", 42),
+        repo=kwargs.get("repo", "392fyc/Mercury"),
+        severity=kwargs.get("severity"),
+        payload=kwargs.get("payload", {}),
+    )
+
+
+# ── Schema tests ──────────────────────────────────────────────────────
+
+class TestArgusEventSchema:
+    def test_all_event_types_defined(self):
+        expected = {
+            "review_started", "finding_posted", "reply_classified",
+            "thread_resolved", "error", "mention_rewritten", "request_blocked",
+        }
+        assert {e.value for e in EventType} == expected
+
+    def test_to_dict_round_trip(self):
+        event = _make_event(EventType.REVIEW_STARTED, severity="Medium",
+                            payload={"iteration": 1})
+        d = event.to_dict()
+        assert d["event_type"] == "review_started"
+        assert d["pr_number"] == 42
+        assert d["payload"]["iteration"] == 1
+        restored = ArgusEvent.from_dict(d)
+        assert restored.event_type == EventType.REVIEW_STARTED
+        assert restored.pr_number == 42
+        assert restored.payload["iteration"] == 1
+
+    def test_from_dict_rejects_unknown_event_type(self):
+        d = _make_event(EventType.ERROR).to_dict()
+        d["event_type"] = "not_a_real_type"
+        with pytest.raises(ValueError):
+            ArgusEvent.from_dict(d)
+
+    @pytest.mark.parametrize("event_type", list(EventType))
+    def test_each_event_type_serializes(self, event_type):
+        event = _make_event(event_type)
+        d = event.to_dict()
+        assert d["event_type"] == event_type.value
+        restored = ArgusEvent.from_dict(d)
+        assert restored.event_type == event_type
+
+
+# ── EventEmitter tests ────────────────────────────────────────────────
+
+class TestEventEmitter:
+    def test_emit_writes_jsonline(self, emitter, tmp_sink):
+        emitter.emit(EventType.REQUEST_BLOCKED, pr_number=1, repo="r/r", actor="eve")
+        assert os.path.exists(tmp_sink)
+        with open(tmp_sink) as fh:
+            lines = [l for l in fh.read().splitlines() if l]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["event_type"] == "request_blocked"
+        assert record["payload"]["actor"] == "eve"
+
+    def test_emit_multiple_events_appends(self, emitter, tmp_sink):
+        emitter.emit(EventType.REVIEW_STARTED, pr_number=10)
+        emitter.emit(EventType.FINDING_POSTED, pr_number=10)
+        emitter.emit(EventType.ERROR, pr_number=10, message="boom")
+        with open(tmp_sink) as fh:
+            lines = [l for l in fh.read().splitlines() if l]
+        assert len(lines) == 3
+        types = [json.loads(l)["event_type"] for l in lines]
+        assert types == ["review_started", "finding_posted", "error"]
+
+    def test_emit_does_not_raise_on_bad_path(self):
+        bad_emitter = EventEmitter(sink_path="/nonexistent/deep/path/events.jsonl")
+        # Should not raise
+        bad_emitter.emit(EventType.ERROR)
+
+    def test_emit_payload_kwargs(self, emitter, tmp_sink):
+        emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=5, verdict="ACCEPT",
+                     thread_path="src/foo.py")
+        with open(tmp_sink) as fh:
+            record = json.loads(fh.readline())
+        assert record["payload"]["verdict"] == "ACCEPT"
+        assert record["payload"]["thread_path"] == "src/foo.py"
+
+
+# ── Extractor round-trip tests ────────────────────────────────────────
+
+class TestReadEvents:
+    def test_empty_file_returns_empty_list(self, tmp_sink):
+        open(tmp_sink, "w").close()
+        assert read_events(sink_path=tmp_sink) == []
+
+    def test_missing_file_returns_empty_list(self, tmp_path):
+        assert read_events(sink_path=str(tmp_path / "missing.jsonl")) == []
+
+    def test_full_round_trip(self, emitter, tmp_sink):
+        emitter.emit(EventType.REVIEW_STARTED, pr_number=7, repo="392fyc/Argus",
+                     iteration=2)
+        emitter.emit(EventType.FINDING_POSTED, pr_number=7, count=3)
+        events = read_events(sink_path=tmp_sink)
+        assert len(events) == 2
+        assert events[0].event_type == EventType.REVIEW_STARTED
+        assert events[0].pr_number == 7
+        assert events[0].payload["iteration"] == 2
+        assert events[1].event_type == EventType.FINDING_POSTED
+        assert events[1].payload["count"] == 3
+
+    def test_filter_by_event_type(self, emitter, tmp_sink):
+        emitter.emit(EventType.REVIEW_STARTED, pr_number=1)
+        emitter.emit(EventType.ERROR, pr_number=1, message="oops")
+        emitter.emit(EventType.FINDING_POSTED, pr_number=1)
+        errors = read_events(sink_path=tmp_sink, event_types=[EventType.ERROR])
+        assert len(errors) == 1
+        assert errors[0].event_type == EventType.ERROR
+
+    def test_filter_by_time_range(self, emitter, tmp_sink):
+        now = datetime.now(timezone.utc)
+        # Write an event, then filter it out with a future `since`
+        emitter.emit(EventType.MENTION_REWRITTEN, pr_number=2)
+        future = now + timedelta(hours=1)
+        events = read_events(sink_path=tmp_sink, since=future)
+        assert events == []
+
+    def test_filter_since_includes_matching(self, emitter, tmp_sink):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        emitter.emit(EventType.THREAD_RESOLVED, pr_number=3)
+        events = read_events(sink_path=tmp_sink, since=past)
+        assert len(events) == 1
+
+    def test_malformed_line_skipped(self, tmp_sink):
+        with open(tmp_sink, "w") as fh:
+            fh.write('not json\n')
+            fh.write(json.dumps(ArgusEvent(
+                event_type=EventType.ERROR,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                payload={},
+            ).to_dict()) + "\n")
+        events = read_events(sink_path=tmp_sink)
+        assert len(events) == 1
+        assert events[0].event_type == EventType.ERROR


### PR DESCRIPTION
## Summary

- Adds `argus_events.py`: `EventType` enum (7 types), `ArgusEvent` dataclass, `EventEmitter` writing jsonlines to configurable sink (`ARGUS_EVENTS_PATH`, default `/var/log/argus/events.jsonl`)
- Adds `argus_extractor.py`: `read_events()` with optional time-range and event-type filters
- Adds `tests/test_events.py`: 21 tests covering schema round-trip, emitter, and extractor (all pass)
- Wires emitter into `entrypoint-guard.py` at 9 print points (request_blocked, error, reply_classified×4, thread_resolved, mention_rewritten)
- Wires emitter into `patch_suggestion_format.py` at review_started and finding_posted

Existing `print()` logs are unchanged. `emitter.emit()` catches `Exception` — never raises, never breaks existing flow. Module-level singleton is lazy-init (no I/O at import time, safe for gunicorn startup).

## Acceptance criteria

- [x] Event schema (dataclass), 7 event types
- [x] Emitter writes to independent sink, existing logs unchanged
- [x] Extractor reads file, returns event list with filters
- [x] Tests: fixtures + round-trip (21/21 pass)
- [x] No changes to configuration.toml model/temperature

## Test plan

- [x] `pytest tests/test_events.py` — 21 passed
- [x] dual-verify: PASS (Claude + Codex, 2 issues fixed before commit)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)