### PR TITLE
feat(m3): M3 self-check agent — adaptive scheduling, direct Python mode, tail-scan extractor

### DIFF
--- a/.claude/skills/log-analyzer/SKILL.md
+++ b/.claude/skills/log-analyzer/SKILL.md
@@ -1,0 +1,52 @@
+# Log Analyzer Skill
+
+Manual invocation of the Argus self-check analysis via Claude Code session.
+
+**This skill is for manual/ad-hoc use.** For scheduled runs, see the deployment
+options in `docs/self-check-setup.md`:
+- **Plan A (primary)**: GitHub Actions + `openai/codex-action@v1` (`.github/workflows/self-check.yml`)
+- **Plan B (fallback)**: Claude Code + ccproxy + LiteLLM (`scripts/run_self_check.sh`)
+
+## When to invoke manually
+
+- You suspect Argus has been misbehaving since the last scheduled run
+- You want to preview findings before the next automatic run
+- You need to test the self-check pipeline after code changes
+
+## Prerequisites
+
+Ensure `ARGUS_EVENTS_PATH` points to the events.jsonl sink with recent data.
+
+## Execution steps
+
+1. **Preview findings (dry run)**:
+   ```bash
+   python argus_self_check.py --days 3 --dry-run
+   ```
+
+2. **Review output** — confirm findings are real, not stale test data
+
+3. **File Issues (production run)**:
+   ```bash
+   python argus_self_check.py --days 3 --max-issues 5
+   ```
+
+4. **Verify** filed Issues at https://github.com/392fyc/Argus/issues?q=label:source:self-check
+
+## What the analyzer checks
+
+| Problem type | Trigger condition |
+|---|---|
+| `error_spike` | ≥3 ERROR events in window |
+| `escalate_overrate` | ≥30% ESCALATE among ≥3 reply events (LLM errors excluded) |
+| `resolution_gap` | ≥3 ACCEPT verdicts without matching THREAD_RESOLVED |
+| `access_pattern` | ≥5 REQUEST_BLOCKED events |
+| `data_gap` | Zero events in window (sensor health check) |
+
+## Safeguards
+
+- Only files Issues to `392fyc/Argus`
+- Max 5 Issues per run (configurable via `--max-issues`)
+- Deduplicates: will not re-file if open Issue with same `sig:` already exists
+- Never modifies source files, configs, or deploy files
+- All hypotheses in filed Issues are marked `UNVERIFIED`

--- a/.github/workflows/self-check.yml
+++ b/.github/workflows/self-check.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           sandbox: workspace-write
-          codex-args: '["--approval-mode", "full-auto"]'
+          codex-args: '["--full-auto"]'
           prompt: |
             Analyze the last ${{ github.event.inputs.days || vars.SELF_CHECK_DAYS || '3' }} days of
             Argus structured events and file GitHub Issues for any detected problems.

--- a/.github/workflows/self-check.yml
+++ b/.github/workflows/self-check.yml
@@ -1,0 +1,81 @@
+# Argus self-check — scheduled log analysis + auto-issue filing
+#
+# Plan A: Codex CLI via openai/codex-action@v1
+# Runs every 3 days; also supports manual dispatch.
+#
+# Required repository secrets:
+#   OPENAI_API_KEY — OpenAI API key with access to the target model
+#
+# Optional repository variables (set under Settings → Variables):
+#   SELF_CHECK_DAYS     — analysis window in days (default: 3)
+#   SELF_CHECK_MAX      — max Issues to file per run (default: 5)
+#   ARGUS_EVENTS_PATH   — path to events.jsonl on the runner (default: /var/log/argus/events.jsonl)
+#
+# To pause: set the repository variable SELF_CHECK_DISABLED=1
+# To re-enable: delete or set SELF_CHECK_DISABLED=0
+
+name: Argus self-check
+
+on:
+  schedule:
+    # Every 3 days at 02:17 UTC (off-peak, avoids :00/:30 crowding)
+    - cron: '17 2 */3 * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Analysis window (days)'
+        required: false
+        default: '3'
+      dry_run:
+        description: 'Dry run (no Issues filed)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  self-check:
+    runs-on: ubuntu-latest
+    # Skip if globally disabled
+    if: vars.SELF_CHECK_DISABLED != '1'
+
+    permissions:
+      issues: write   # needed for gh issue create
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run self-check via Codex CLI
+        # Inputs verified from openai/codex-action v1 action.yml:
+        #   https://raw.githubusercontent.com/openai/codex-action/v1/action.yml
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: workspace-write
+          codex-args: '["--approval-mode", "full-auto"]'
+          prompt: |
+            Analyze the last ${{ github.event.inputs.days || vars.SELF_CHECK_DAYS || '3' }} days of
+            Argus structured events and file GitHub Issues for any detected problems.
+
+            Steps:
+            1. Run: python argus_self_check.py --days ${{ github.event.inputs.days || vars.SELF_CHECK_DAYS || '3' }} ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }} --max-issues ${{ vars.SELF_CHECK_MAX || '5' }}
+            2. Print the output verbatim.
+            3. If any Issues were filed, list their URLs.
+            4. If the run failed, print the error and exit 1.
+
+            Constraints:
+            - Do NOT modify any source files, configs, or deploy files.
+            - Do NOT file Issues to any repo other than 392fyc/Argus.
+            - Do NOT exceed ${{ vars.SELF_CHECK_MAX || '5' }} Issues per run.
+        env:
+          ARGUS_EVENTS_PATH: ${{ vars.ARGUS_EVENTS_PATH || '/var/log/argus/events.jsonl' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ docker-compose.override.yml
 
 # Local state — Claude Code skill working files
 .claude/state/
+
+# Argus event log (bind-mounted from Docker container, not for VCS)
+logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Argus — Codex Agent Instructions
+
+## Identity
+
+Agent: Codex CLI
+Repo: 392fyc/Argus
+Purpose: Self-hosted PR review bot running on QNAP NAS via Docker.
+Stack: Python 3 · PR-Agent 0.34 · GitHub App webhook · ASGI (gunicorn)
+
+## Navigation
+
+| Topic | Path |
+|-------|------|
+| Structured event schema | `argus_events.py` |
+| Event extractor | `argus_extractor.py` |
+| Self-check analyzer | `argus_log_analyzer.py` |
+| Self-check formatter | `argus_issue_formatter.py` |
+| Self-check orchestrator | `argus_self_check.py` |
+| Self-check setup docs | `docs/self-check-setup.md` |
+| Webhook guard + @mention patch | `entrypoint-guard.py` |
+| CodeRabbit-style suggestion format | `patch_suggestion_format.py` |
+| ADR: code-reading capability | `docs/adr/0001-code-reading-capability.md` |
+
+## Self-check task (M3)
+
+When asked to "run the Argus self-check" or "analyze recent logs":
+
+1. Run `python argus_self_check.py --days 3` in the working directory
+2. Print all output verbatim
+3. Report the number of Issues filed and their URLs
+4. Do NOT modify any source files, configuration files, or deploy files
+5. Do NOT file Issues to any repo other than `392fyc/Argus`
+6. Do NOT exceed 5 Issues per run
+
+For preview without filing: `python argus_self_check.py --days 3 --dry-run`
+
+## MUST
+
+- Never modify `entrypoint-guard.py`, `patch_suggestion_format.py`, or any gunicorn/Docker config
+- Never push code or create PRs — analysis and issue filing only
+- Always print full `argus_self_check.py` output before summarizing
+- If `ARGUS_EVENTS_PATH` is not set and `/var/log/argus/events.jsonl` does not exist, report the missing path and stop
+
+## DO NOT
+
+- Do not modify Argus source code in self-check runs
+- Do not create or delete files outside the analysis pipeline
+- Do not access external URLs other than GitHub API (via `gh` CLI)

--- a/argus_events.py
+++ b/argus_events.py
@@ -1,0 +1,105 @@
+"""
+Argus structured event schema and emitter.
+
+Writes machine-readable events to a jsonlines sink independently of the
+existing print-based log, so neither the existing log format nor the
+PR-Agent pipeline is affected.
+
+Sink path: $ARGUS_EVENTS_PATH (default: /var/log/argus/events.jsonl)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+
+class EventType(str, Enum):
+    REVIEW_STARTED = "review_started"
+    FINDING_POSTED = "finding_posted"
+    REPLY_CLASSIFIED = "reply_classified"
+    THREAD_RESOLVED = "thread_resolved"
+    ERROR = "error"
+    MENTION_REWRITTEN = "mention_rewritten"
+    REQUEST_BLOCKED = "request_blocked"
+
+
+@dataclass
+class ArgusEvent:
+    event_type: EventType
+    timestamp: str
+    pr_number: Optional[int] = None
+    repo: Optional[str] = None
+    severity: Optional[str] = None  # Critical | Major | Medium | Minor | None
+    payload: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["event_type"] = self.event_type.value
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ArgusEvent":
+        d = dict(d)
+        d["event_type"] = EventType(d["event_type"])
+        return cls(**d)
+
+
+_DEFAULT_SINK = "/var/log/argus/events.jsonl"
+
+
+class EventEmitter:
+    """Writes ArgusEvent records as jsonlines to a configurable sink file."""
+
+    def __init__(self, sink_path: Optional[str] = None):
+        self._path = sink_path or os.environ.get("ARGUS_EVENTS_PATH", _DEFAULT_SINK)
+        self._ready: Optional[bool] = None  # lazy init
+        self._lock = threading.Lock()  # guards concurrent file appends
+
+    def _ensure_sink(self) -> bool:
+        if self._ready is not None:
+            return self._ready
+        try:
+            dirpath = os.path.dirname(self._path)
+            if dirpath:
+                os.makedirs(dirpath, exist_ok=True)
+            self._ready = True
+        except Exception as e:
+            print(f"[Argus Events] Cannot create sink directory: {e}")
+            self._ready = False
+        return self._ready
+
+    def emit(
+        self,
+        event_type: EventType,
+        pr_number: Optional[int] = None,
+        repo: Optional[str] = None,
+        severity: Optional[str] = None,
+        **payload_kwargs: Any,
+    ) -> None:
+        """Emit a structured event. Never raises — errors are print-logged only."""
+        if not self._ensure_sink():
+            return
+        event = ArgusEvent(
+            event_type=event_type,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            pr_number=pr_number,
+            repo=repo,
+            severity=severity,
+            payload=payload_kwargs,
+        )
+        try:
+            with self._lock:
+                with open(self._path, "a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(event.to_dict()) + "\n")
+        except Exception as e:
+            print(f"[Argus Events] Emit failed: {e}")
+
+
+# Module-level singleton — imported by entrypoint-guard and patch_suggestion_format
+emitter = EventEmitter()

--- a/argus_extractor.py
+++ b/argus_extractor.py
@@ -16,6 +16,12 @@ from argus_events import ArgusEvent, EventType
 
 _DEFAULT_SINK = "/var/log/argus/events.jsonl"
 
+# Tail-scan limit: only read the last N bytes of a large events file.
+# Events are appended chronologically, so recent events are always at the end.
+# 5 MB covers ~7 days of typical Argus activity with headroom to spare.
+# Applied only when `since` is provided (i.e., bounded analysis windows).
+_MAX_TAIL_BYTES = 5 * 1024 * 1024  # 5 MB
+
 
 def read_events(
     sink_path: Optional[str] = None,
@@ -46,6 +52,20 @@ def read_events(
         print(f"[Argus Extractor] Cannot open sink: {e}")
         return events
     with fh:
+        # Tail-scan optimisation: when a lower-bound timestamp is given and the
+        # file exceeds _MAX_TAIL_BYTES, seek near the end so we skip old events
+        # that are guaranteed to fall outside the analysis window.
+        # Events are appended in chronological order, so recent events are at
+        # the end. The first (possibly partial) line after the seek is discarded.
+        if since is not None:
+            try:
+                file_size = os.path.getsize(path)
+                if file_size > _MAX_TAIL_BYTES:
+                    fh.seek(max(0, file_size - _MAX_TAIL_BYTES))
+                    fh.readline()  # discard partial line at seek boundary
+            except OSError:
+                pass  # fall back to full scan on any seek error
+
         for lineno, line in enumerate(fh, 1):
             line = line.strip()
             if not line:

--- a/argus_extractor.py
+++ b/argus_extractor.py
@@ -1,0 +1,80 @@
+"""
+Argus event extractor.
+
+Reads events from the jsonlines sink and returns a filtered list of
+ArgusEvent objects. Supports optional time-range and event-type filtering.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from argus_events import ArgusEvent, EventType
+
+_DEFAULT_SINK = "/var/log/argus/events.jsonl"
+
+
+def read_events(
+    sink_path: Optional[str] = None,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    event_types: Optional[List[EventType]] = None,
+) -> List[ArgusEvent]:
+    """Read events from the jsonlines sink.
+
+    Args:
+        sink_path: Path to the events.jsonl file. Defaults to
+            $ARGUS_EVENTS_PATH or /var/log/argus/events.jsonl.
+        since: Include only events at or after this timestamp (UTC-aware).
+        until: Include only events at or before this timestamp (UTC-aware).
+        event_types: Whitelist of EventType values to include. None = all.
+
+    Returns:
+        List of ArgusEvent objects matching the filters, in file order.
+    """
+    path = sink_path or os.environ.get("ARGUS_EVENTS_PATH", _DEFAULT_SINK)
+    if not os.path.exists(path):
+        return []
+
+    events: List[ArgusEvent] = []
+    try:
+        fh = open(path, encoding="utf-8")
+    except OSError as e:
+        print(f"[Argus Extractor] Cannot open sink: {e}")
+        return events
+    with fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                raw = json.loads(line)
+                event = ArgusEvent.from_dict(raw)
+            except Exception as e:
+                print(f"[Argus Extractor] Skipping malformed line {lineno}: {e}")
+                continue
+
+            if event_types is not None and event.event_type not in event_types:
+                continue
+
+            if since is not None or until is not None:
+                # Normalize caller's datetimes to UTC-aware to prevent TypeError
+                _since = since.replace(tzinfo=timezone.utc) if since is not None and since.tzinfo is None else since
+                _until = until.replace(tzinfo=timezone.utc) if until is not None and until.tzinfo is None else until
+                try:
+                    ts = datetime.fromisoformat(event.timestamp)
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    if _since is not None and ts < _since:
+                        continue
+                    if _until is not None and ts > _until:
+                        continue
+                except (ValueError, TypeError):
+                    pass  # unparseable timestamp — include anyway
+
+            events.append(event)
+
+    return events

--- a/argus_issue_formatter.py
+++ b/argus_issue_formatter.py
@@ -1,0 +1,124 @@
+"""
+Argus Issue formatter.
+
+Converts a ProblemCluster into a GitHub Issue title + body + label list
+that matches the Argus repo's issue conventions.
+
+Usage::
+
+    from argus_issue_formatter import format_issue
+    title, body, labels = format_issue(cluster, since_iso, until_iso)
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from argus_log_analyzer import (
+    ProblemCluster,
+    SEVERITY_CRITICAL,
+    SEVERITY_HIGH,
+    SEVERITY_MEDIUM,
+    SEVERITY_LOW,
+    TYPE_ERROR_SPIKE,
+    TYPE_ESCALATE_OVERRATE,
+    TYPE_RESOLUTION_GAP,
+    TYPE_ACCESS_PATTERN,
+    TYPE_DATA_GAP,
+)
+
+
+_SEVERITY_EMOJI = {
+    SEVERITY_CRITICAL: "🔴",
+    SEVERITY_HIGH: "🟠",
+    SEVERITY_MEDIUM: "🟡",
+    SEVERITY_LOW: "🔵",
+}
+
+_TYPE_TO_ISSUE_TYPE = {
+    TYPE_ERROR_SPIKE: "type:bug",
+    TYPE_ESCALATE_OVERRATE: "type:bug",
+    TYPE_RESOLUTION_GAP: "type:bug",
+    TYPE_ACCESS_PATTERN: "type:analysis",
+    TYPE_DATA_GAP: "type:bug",
+}
+
+_SEVERITY_TO_PRIORITY = {
+    SEVERITY_CRITICAL: "priority:p0",
+    SEVERITY_HIGH: "priority:p1",
+    SEVERITY_MEDIUM: "priority:p2",
+    SEVERITY_LOW: "priority:p2",
+}
+
+_TYPE_TO_DESCRIPTION = {
+    TYPE_ERROR_SPIKE: "error spike detected in structured event log",
+    TYPE_ESCALATE_OVERRATE: "reply classifier ESCALATE rate exceeds threshold",
+    TYPE_RESOLUTION_GAP: "threads accepted but not formally resolved",
+    TYPE_ACCESS_PATTERN: "blocked request pattern observed",
+    TYPE_DATA_GAP: "no events recorded — sensor health check needed",
+}
+
+
+def format_issue(
+    cluster: ProblemCluster,
+    since_iso: str,
+    until_iso: str,
+) -> Tuple[str, str, List[str]]:
+    """Return (title, body, labels) for a ProblemCluster.
+
+    Args:
+        cluster: The detected problem.
+        since_iso: ISO 8601 start of analysis window (for traceability).
+        until_iso: ISO 8601 end of analysis window.
+
+    Returns:
+        Tuple of (issue_title, issue_body_markdown, label_list).
+    """
+    emoji = _SEVERITY_EMOJI.get(cluster.severity, "⚪")
+    short_desc = _TYPE_TO_DESCRIPTION.get(cluster.type, cluster.type)
+
+    title = f"[self-check] {emoji} {short_desc} — sig:{cluster.signature}"
+
+    evidence_md = "\n".join(f"- {e}" for e in cluster.evidence)
+    body = f"""\
+## Self-check finding
+
+**Severity**: {cluster.severity}
+**Type**: `{cluster.type}`
+**Analysis window**: `{since_iso}` → `{until_iso}`
+**Dedup signature**: `{cluster.signature}`
+
+> This Issue was auto-filed by the Argus self-check agent. It has NOT been
+> manually verified. All hypotheses are marked accordingly.
+
+---
+
+## Observed evidence
+
+{evidence_md}
+
+## Hypothesis (UNVERIFIED)
+
+{cluster.hypothesis}
+
+---
+
+## Suggested next step
+
+1. Pull recent structured events: `python argus_self_check.py --days 3 --dry-run`
+2. Inspect the relevant event type in the jsonl sink
+3. Confirm or refute the hypothesis before filing a fix PR
+
+## Labels
+
+This issue is tagged `source:self-check` — it was generated automatically.
+To suppress future reports of this type, resolve or close this Issue
+(the dedup check will not re-file while an open Issue with the same signature exists).
+"""
+
+    labels = [
+        "source:self-check",
+        _TYPE_TO_ISSUE_TYPE.get(cluster.type, "type:analysis"),
+        _SEVERITY_TO_PRIORITY.get(cluster.severity, "priority:p2"),
+    ]
+    return title, body, labels

--- a/argus_log_analyzer.py
+++ b/argus_log_analyzer.py
@@ -59,6 +59,10 @@ class ProblemCluster:
             self.signature = hashlib.sha256(raw).hexdigest()[:16]
 
 
+# ── Defaults ─────────────────────────────────────────────────────────────────
+
+_DEFAULT_SINK = "/var/log/argus/events.jsonl"
+
 # ── Thresholds ────────────────────────────────────────────────────────────────
 
 _ERROR_SPIKE_THRESHOLD = 3          # errors in window → spike

--- a/argus_log_analyzer.py
+++ b/argus_log_analyzer.py
@@ -1,0 +1,239 @@
+"""
+Argus log analyzer.
+
+Reads structured events from the M2 schema and groups them into ProblemCluster
+objects. Each cluster carries observed facts (evidence) and an UNVERIFIED
+hypothesis suitable for filing as a GitHub Issue.
+
+Usage::
+
+    from datetime import datetime, timezone, timedelta
+    from argus_log_analyzer import analyze
+
+    since = datetime.now(timezone.utc) - timedelta(days=3)
+    clusters = analyze(since=since)
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from argus_events import EventType
+from argus_extractor import read_events
+
+
+# ── Problem severity ──────────────────────────────────────────────────────────
+
+SEVERITY_CRITICAL = "critical"
+SEVERITY_HIGH = "high"
+SEVERITY_MEDIUM = "medium"
+SEVERITY_LOW = "low"
+
+
+# ── Problem types ─────────────────────────────────────────────────────────────
+
+TYPE_ERROR_SPIKE = "error_spike"
+TYPE_ESCALATE_OVERRATE = "escalate_overrate"
+TYPE_RESOLUTION_GAP = "resolution_gap"
+TYPE_ACCESS_PATTERN = "access_pattern"
+TYPE_DATA_GAP = "data_gap"
+
+
+@dataclass
+class ProblemCluster:
+    """One distinct problem detected in the analysis window."""
+
+    type: str
+    severity: str
+    title: str
+    evidence: List[str] = field(default_factory=list)  # observed facts
+    hypothesis: str = ""  # UNVERIFIED hypothesis
+    signature: str = ""  # sha256 used for deduplication
+
+    def __post_init__(self) -> None:
+        if not self.signature:
+            raw = f"{self.type}:{self.title}".encode()
+            self.signature = hashlib.sha256(raw).hexdigest()[:16]
+
+
+# ── Thresholds ────────────────────────────────────────────────────────────────
+
+_ERROR_SPIKE_THRESHOLD = 3          # errors in window → spike
+_ESCALATE_RATIO_THRESHOLD = 0.30    # ≥30 % escalates → over-escalating
+_MIN_REPLIES_FOR_ESCALATE = 3       # require ≥3 replies before checking ratio
+_ACCEPT_WITHOUT_RESOLVE_THRESHOLD = 3  # ACCEPT verdicts without THREAD_RESOLVED
+_BLOCKED_THRESHOLD = 5              # blocked requests → flag pattern
+
+
+def analyze(
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    sink_path: Optional[str] = None,
+) -> List[ProblemCluster]:
+    """Return a list of ProblemCluster objects for the given time window.
+
+    Args:
+        since: Start of analysis window (UTC-aware). None = no lower bound.
+        until: End of analysis window (UTC-aware). None = now.
+        sink_path: Override for the events.jsonl path. Uses ARGUS_EVENTS_PATH
+            or the default /var/log/argus/events.jsonl when None.
+
+    Returns:
+        List of ProblemCluster objects ordered by severity (critical first).
+        Returns [] without filing a cluster if the sink file does not exist —
+        a missing file is an infrastructure/config issue, not an Argus problem.
+    """
+    import os as _os
+    resolved_path = sink_path or _os.environ.get("ARGUS_EVENTS_PATH", _DEFAULT_SINK)
+    if not _os.path.exists(resolved_path):
+        print(
+            f"[self-check] Sink not found: {resolved_path} — "
+            "verify ARGUS_EVENTS_PATH and re-run."
+        )
+        return []
+
+    events = read_events(sink_path=resolved_path, since=since, until=until)
+
+    clusters: List[ProblemCluster] = []
+
+    # ── 1. Data gap: sink exists but no events in window ──────────────────────
+    if not events:
+        clusters.append(ProblemCluster(
+            type=TYPE_DATA_GAP,
+            severity=SEVERITY_HIGH,
+            title="No events recorded in analysis window",
+            evidence=[
+                "Sink file exists but zero events found in the requested time window.",
+                f"Sink: {resolved_path}",
+            ],
+            hypothesis=(
+                "UNVERIFIED: Argus may have been idle (no PRs reviewed), "
+                "the emitter may be failing silently, or the analysis window "
+                "may not align with recent activity."
+            ),
+        ))
+        return clusters
+
+    # ── 2. ERROR spike ────────────────────────────────────────────────────────
+    error_events = [e for e in events if e.event_type == EventType.ERROR]
+    if len(error_events) >= _ERROR_SPIKE_THRESHOLD:
+        messages = list({
+            e.payload.get("message", "<no message>") for e in error_events
+        })
+        clusters.append(ProblemCluster(
+            type=TYPE_ERROR_SPIKE,
+            severity=SEVERITY_HIGH if len(error_events) >= 5 else SEVERITY_MEDIUM,
+            title=f"ERROR spike: {len(error_events)} errors in window",
+            evidence=[
+                f"Observed {len(error_events)} ERROR events.",
+                f"Distinct messages ({len(messages)}): "
+                + "; ".join(messages[:5])
+                + ("…" if len(messages) > 5 else ""),
+            ],
+            hypothesis=(
+                "UNVERIFIED: repeated errors may indicate a broken dependency "
+                "(e.g., missing app installation token, GitHub API rate limit, "
+                "or unhandled exception in reply handler)."
+            ),
+        ))
+
+    # ── 3. Over-escalating classifier ────────────────────────────────────────
+    reply_events = [
+        e for e in events if e.event_type == EventType.REPLY_CLASSIFIED
+    ]
+    escalate_events = [
+        e for e in reply_events
+        if e.payload.get("verdict") == "ESCALATE"
+        and "LLM error" not in e.payload.get("reason", "")
+    ]
+    if (
+        len(reply_events) >= _MIN_REPLIES_FOR_ESCALATE
+        and len(escalate_events) / len(reply_events) >= _ESCALATE_RATIO_THRESHOLD
+    ):
+        ratio_pct = round(len(escalate_events) / len(reply_events) * 100)
+        clusters.append(ProblemCluster(
+            type=TYPE_ESCALATE_OVERRATE,
+            severity=SEVERITY_MEDIUM,
+            title=f"Reply classifier ESCALATE rate {ratio_pct}% exceeds threshold",
+            evidence=[
+                f"Observed {len(reply_events)} REPLY_CLASSIFIED events.",
+                f"{len(escalate_events)} verdicts were ESCALATE ({ratio_pct}%).",
+                f"Threshold: {int(_ESCALATE_RATIO_THRESHOLD * 100)}%.",
+            ],
+            hypothesis=(
+                "UNVERIFIED: the LLM prompt may be too conservative, or the "
+                "sample of replies genuinely required escalation (e.g., all from "
+                "a complex PR). Check individual thread_path values for patterns."
+            ),
+        ))
+
+    # ── 4. Resolution gap (ACCEPT without THREAD_RESOLVED) ───────────────────
+    accept_paths = {
+        e.payload.get("thread_path")
+        for e in reply_events
+        if e.payload.get("verdict") == "ACCEPT"
+    }
+    resolved_paths = {
+        e.payload.get("thread_path")
+        for e in events
+        if e.event_type == EventType.THREAD_RESOLVED
+    }
+    unresolved_accepts = accept_paths - resolved_paths - {None}
+    if len(unresolved_accepts) >= _ACCEPT_WITHOUT_RESOLVE_THRESHOLD:
+        clusters.append(ProblemCluster(
+            type=TYPE_RESOLUTION_GAP,
+            severity=SEVERITY_MEDIUM,
+            title=(
+                f"{len(unresolved_accepts)} threads accepted but not resolved"
+            ),
+            evidence=[
+                f"{len(accept_paths)} ACCEPT verdicts, "
+                f"{len(resolved_paths)} THREAD_RESOLVED events.",
+                f"{len(unresolved_accepts)} thread paths appear in ACCEPT but "
+                "not in THREAD_RESOLVED.",
+                "Sample paths: "
+                + ", ".join(sorted(unresolved_accepts)[:3])
+                + ("…" if len(unresolved_accepts) > 3 else ""),
+            ],
+            hypothesis=(
+                "UNVERIFIED: _resolve_thread() may have failed silently after "
+                "posting the Acknowledged reply, or the GraphQL mutation response "
+                "was not awaited correctly."
+            ),
+        ))
+
+    # ── 5. Access control pattern ─────────────────────────────────────────────
+    blocked_events = [
+        e for e in events if e.event_type == EventType.REQUEST_BLOCKED
+    ]
+    if len(blocked_events) >= _BLOCKED_THRESHOLD:
+        actors = list({e.payload.get("actor", "<unknown>") for e in blocked_events})
+        clusters.append(ProblemCluster(
+            type=TYPE_ACCESS_PATTERN,
+            severity=SEVERITY_LOW,
+            title=f"{len(blocked_events)} blocked requests in window",
+            evidence=[
+                f"Observed {len(blocked_events)} REQUEST_BLOCKED events.",
+                f"Distinct actors ({len(actors)}): "
+                + ", ".join(actors[:5])
+                + ("…" if len(actors) > 5 else ""),
+            ],
+            hypothesis=(
+                "UNVERIFIED: may indicate unauthorized probe activity, a "
+                "misconfigured whitelist, or a legitimate user not yet added "
+                "to ARGUS_ALLOWED_USERS."
+            ),
+        ))
+
+    # Sort: critical → high → medium → low
+    _order = {
+        SEVERITY_CRITICAL: 0,
+        SEVERITY_HIGH: 1,
+        SEVERITY_MEDIUM: 2,
+        SEVERITY_LOW: 3,
+    }
+    clusters.sort(key=lambda c: _order.get(c.severity, 9))
+    return clusters

--- a/argus_log_analyzer.py
+++ b/argus_log_analyzer.py
@@ -174,18 +174,44 @@ def analyze(
             ),
         ))
 
-    # ── 4. Resolution gap (ACCEPT without THREAD_RESOLVED) ───────────────────
-    accept_paths = {
-        e.payload.get("thread_path")
-        for e in reply_events
-        if e.payload.get("verdict") == "ACCEPT"
+    # ── 4. Resolution gap (ACCEPT without subsequent THREAD_RESOLVED) ────────
+    # Use latest-timestamp comparison per thread_path so that a thread which
+    # was resolved *before* a later ACCEPT is correctly flagged as unresolved.
+    _min_dt = datetime.min.replace(tzinfo=timezone.utc)
+
+    last_accept: dict = {}
+    for e in reply_events:
+        if e.payload.get("verdict") == "ACCEPT":
+            path = e.payload.get("thread_path")
+            if path:
+                try:
+                    ts = datetime.fromisoformat(e.timestamp)
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                except (ValueError, TypeError):
+                    ts = _min_dt
+                if path not in last_accept or ts > last_accept[path]:
+                    last_accept[path] = ts
+
+    last_resolved: dict = {}
+    for e in events:
+        if e.event_type == EventType.THREAD_RESOLVED:
+            path = e.payload.get("thread_path")
+            if path:
+                try:
+                    ts = datetime.fromisoformat(e.timestamp)
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                except (ValueError, TypeError):
+                    ts = _min_dt
+                if path not in last_resolved or ts > last_resolved[path]:
+                    last_resolved[path] = ts
+
+    # Unresolved: last ACCEPT is more recent than last RESOLVED (or never resolved)
+    unresolved_accepts = {
+        path for path, accept_ts in last_accept.items()
+        if path not in last_resolved or accept_ts > last_resolved[path]
     }
-    resolved_paths = {
-        e.payload.get("thread_path")
-        for e in events
-        if e.event_type == EventType.THREAD_RESOLVED
-    }
-    unresolved_accepts = accept_paths - resolved_paths - {None}
     if len(unresolved_accepts) >= _ACCEPT_WITHOUT_RESOLVE_THRESHOLD:
         clusters.append(ProblemCluster(
             type=TYPE_RESOLUTION_GAP,
@@ -194,10 +220,10 @@ def analyze(
                 f"{len(unresolved_accepts)} threads accepted but not resolved"
             ),
             evidence=[
-                f"{len(accept_paths)} ACCEPT verdicts, "
-                f"{len(resolved_paths)} THREAD_RESOLVED events.",
-                f"{len(unresolved_accepts)} thread paths appear in ACCEPT but "
-                "not in THREAD_RESOLVED.",
+                f"{len(last_accept)} ACCEPT verdicts, "
+                f"{len(last_resolved)} THREAD_RESOLVED events.",
+                f"{len(unresolved_accepts)} thread paths have ACCEPT more recent "
+                "than their last THREAD_RESOLVED (or were never resolved).",
                 "Sample paths: "
                 + ", ".join(sorted(unresolved_accepts)[:3])
                 + ("…" if len(unresolved_accepts) > 3 else ""),

--- a/argus_self_check.py
+++ b/argus_self_check.py
@@ -1,0 +1,201 @@
+"""
+Argus self-check orchestrator.
+
+Runs the log analyzer over a configurable time window, formats findings as
+GitHub Issues, deduplicates against open Issues, and files new ones (up to
+a per-run cap).
+
+Usage::
+
+    # Preview (no Issues filed):
+    python argus_self_check.py --days 3 --dry-run
+
+    # Production run (files up to 5 Issues):
+    python argus_self_check.py --days 3
+
+    # Custom window:
+    python argus_self_check.py --days 7 --max-issues 3
+
+Environment variables:
+    ARGUS_EVENTS_PATH  Path to events.jsonl (default: /var/log/argus/events.jsonl)
+    GH_TOKEN           GitHub token with issues:write scope (used by gh CLI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from datetime import datetime, timezone, timedelta
+from typing import List
+
+from argus_log_analyzer import analyze, ProblemCluster
+from argus_issue_formatter import format_issue
+
+_REPO = "392fyc/Argus"
+_DEFAULT_DAYS = 3
+_DEFAULT_MAX_ISSUES = 5
+
+
+def _is_duplicate(signature: str) -> bool:
+    """Return True if an open Issue with the given signature already exists."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", _REPO,
+                "--state", "open",
+                "--search", f"sig:{signature}",
+                "--limit", "5",
+                "--json", "number",
+            ],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("[self-check] WARNING: gh CLI not found — skipping dedup check")
+        return False  # fail-open
+    if result.returncode != 0:
+        print(f"[self-check] WARNING: dedup check failed: {result.stderr.strip()}")
+        return False  # fail-open: allow filing rather than silently skip
+    import json
+    try:
+        issues = json.loads(result.stdout)
+        return len(issues) > 0
+    except Exception:
+        return False
+
+
+def _file_issue(title: str, body: str, labels: List[str]) -> int:
+    """Create a GitHub Issue.
+
+    Returns:
+        Positive integer  — new issue number (success, number known)
+        0                 — issue filed but URL was not parseable (success, number unknown)
+        -1                — gh CLI call failed (issue NOT filed)
+    """
+    label_args = []
+    for lbl in labels:
+        label_args += ["--label", lbl]
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "create",
+                "--repo", _REPO,
+                "--title", title,
+                "--body", body,
+            ] + label_args,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("[self-check] ERROR: gh CLI not found — cannot file issue")
+        return -1
+    if result.returncode != 0:
+        print(f"[self-check] ERROR filing issue: {result.stderr.strip()}")
+        return -1
+    # gh prints the issue URL; extract the number
+    url = result.stdout.strip()
+    try:
+        return int(url.rstrip("/").rsplit("/", 1)[-1])
+    except ValueError:
+        # Filed successfully but number not parseable from URL
+        print(f"[self-check] Issue filed (URL: {url})")
+        return 0  # >= 0 → caller counts as filed
+
+
+def run(
+    days: int = _DEFAULT_DAYS,
+    max_issues: int = _DEFAULT_MAX_ISSUES,
+    dry_run: bool = False,
+    sink_path: str | None = None,
+) -> int:
+    """Run the self-check and return the number of Issues filed (0 in dry-run).
+
+    Safeguards enforced here (in addition to issue.md safeguards):
+    - Only targets _REPO (392fyc/Argus) — hardcoded, not configurable
+    - Caps at max_issues per run
+    - Deduplicates by signature against open Issues
+    - Never modifies code or configuration files
+    """
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=days)
+    since_iso = since.isoformat()
+    until_iso = now.isoformat()
+
+    print(f"[self-check] Analyzing {days}-day window: {since_iso} → {until_iso}")
+    clusters: List[ProblemCluster] = analyze(since=since, until=now, sink_path=sink_path)
+    print(f"[self-check] {len(clusters)} problem cluster(s) found")
+
+    if not clusters:
+        print("[self-check] No problems detected — done.")
+        return 0
+
+    filed = 0
+    for cluster in clusters:
+        if filed >= max_issues:
+            print(f"[self-check] Reached max_issues cap ({max_issues}); stopping.")
+            break
+
+        title, body, labels = format_issue(cluster, since_iso, until_iso)
+        print(f"\n[self-check] Cluster: {cluster.type} | {cluster.severity}")
+        print(f"  Title: {title[:80]}")
+        print(f"  Evidence: {'; '.join(cluster.evidence[:2])[:120]}")
+
+        if dry_run:
+            print("  [dry-run] Would file issue — skipping")
+            continue
+
+        if _is_duplicate(cluster.signature):
+            print(f"  [dedup] Open issue with sig:{cluster.signature} exists — skipping")
+            continue
+
+        issue_num = _file_issue(title, body, labels)
+        if issue_num > 0:
+            print(f"  Filed: {_REPO}#{issue_num}")
+            filed += 1
+        elif issue_num == 0:
+            print(f"  Filed: {_REPO} (issue number unknown — check repo)")
+            filed += 1
+        else:
+            print(f"  ERROR: failed to file issue for cluster {cluster.type}")
+
+    print(f"\n[self-check] Done. {filed} issue(s) filed.")
+    return filed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Argus self-check: analyze structured events and file Issues."
+    )
+    parser.add_argument(
+        "--days", type=int, default=_DEFAULT_DAYS,
+        help=f"Analysis window in days (default: {_DEFAULT_DAYS})"
+    )
+    parser.add_argument(
+        "--max-issues", type=int, default=_DEFAULT_MAX_ISSUES,
+        help=f"Max Issues to file per run (default: {_DEFAULT_MAX_ISSUES})"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print findings without filing any Issues"
+    )
+    parser.add_argument(
+        "--sink-path", type=str, default=None,
+        help="Override path to events.jsonl (overrides ARGUS_EVENTS_PATH)"
+    )
+    args = parser.parse_args()
+
+    filed = run(
+        days=args.days,
+        max_issues=args.max_issues,
+        dry_run=args.dry_run,
+        sink_path=args.sink_path,
+    )
+    # Exit 2 when issues were filed (signals "findings detected" to adaptive scheduler).
+    # Exit 0 when quiet (no issues). Unhandled exceptions propagate as exit 1.
+    sys.exit(2 if filed > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./configuration.toml:/app/pr_agent/settings/configuration.toml:ro
       - ./.secrets.toml:/app/pr_agent/settings/.secrets.toml:ro
-      - argus-logs:/var/log/argus
+      - ./logs:/var/log/argus
     logging:
       driver: json-file
       options:
@@ -41,5 +41,3 @@ services:
         max-size: "5m"
         max-file: "3"
 
-volumes:
-  argus-logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,35 @@ services:
       retries: 3
       start_period: 15s
 
+  # ── Self-check scheduler ────────────────────────────────────────
+  # Runs argus_self_check.py daily. Uses adaptive interval gate in
+  # run_self_check.sh (starts at 3 days, grows to 7 on quiet runs).
+  # Does NOT require NAS crontab access — scheduling is internal.
+  selfcheck-scheduler:
+    image: argus-selfcheck
+    container_name: argus-selfcheck-scheduler
+    restart: unless-stopped
+    environment:
+      - USE_DIRECT_PYTHON=1
+      - EVENTS_HOST_PATH=/var/log/argus/events.jsonl
+      - ARGUS_STATE_FILE=/var/log/argus/self-check-state.json
+    volumes:
+      - ./logs:/var/log/argus
+      - .:/workspace:ro
+    working_dir: /workspace
+    # Poll every 24 h; the adaptive interval gate inside run_self_check.sh
+    # decides whether the actual check runs on any given day.
+    command: >
+      sh -c "while true;
+        do bash scripts/run_self_check.sh >> /var/log/argus/self-check.log 2>&1;
+        sleep 86400;
+      done"
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
+
   # ── Cloudflare Tunnel ───────────────────────────────────────────
   cloudflared:
     image: cloudflare/cloudflared:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
   # run_self_check.sh (starts at 3 days, grows to 7 on quiet runs).
   # Does NOT require NAS crontab access — scheduling is internal.
   selfcheck-scheduler:
+    build:
+      context: .
+      dockerfile: scripts/Dockerfile.codex
     image: argus-selfcheck
     container_name: argus-selfcheck-scheduler
     restart: unless-stopped

--- a/docs/adr/0001-code-reading-capability.md
+++ b/docs/adr/0001-code-reading-capability.md
@@ -1,0 +1,128 @@
+# ADR 0001: Code-Reading Capability for Argus Review
+
+**Status**: Accepted  
+**Date**: 2026-04-12  
+**Issue**: 392fyc/Argus#9  
+
+---
+
+## Context
+
+Argus reviews PRs using the diff and PR metadata. `patch_suggestion_format.py` already
+drops findings whose `relevant_file` / `end_line` cannot be mapped into the diff, but a
+narrower false-positive pattern remains: Argus sometimes suggests mitigations referencing
+file paths or function names that are not part of the change (e.g., "add error handling
+in `utils/helpers.py`" when that file is untouched). This erodes reviewer trust over time.
+
+Four options were considered for extending Argus's awareness beyond the diff.
+
+---
+
+## Decision Drivers
+
+- Low operational overhead (no new infrastructure)
+- Minimal latency impact on the review path
+- Implementable without restructuring the existing monkey-patch pipeline
+- False-negative rate for suppression should be acceptable (better to show an uncertain finding than suppress a valid one)
+
+---
+
+## Options Evaluated
+
+### Option 1 — File existence check
+Verify that any file referenced in a finding exists in the repository.
+
+- **Pro**: Simple, zero latency overhead.
+- **Con**: Does not validate whether the referenced file is relevant to the change.
+  A file can exist in the repo but have nothing to do with the diff.
+
+### Option 2 — Diff-scope intersection ✅ (chosen)
+Check whether referenced identifiers (file paths, function/class names extracted from
+finding text) appear in the PR diff's changed lines (`+` prefix). Suppress or downgrade
+findings where no referenced identifier has any intersection with the diff.
+
+**Scope as implemented**: intersection is computed against `+` diff lines only (not
+import graphs or transitive call sites). This is a deliberate narrowing from the broader
+"files directly touched" framing — import-graph traversal belongs to a future iteration
+once the baseline false-positive rate is measured.
+
+- **Pro**: Catches the primary failure mode without embedding or sub-calls. ~100–150 lines
+  in a new `argus_code_filter.py` module, called once per review event before the results
+  are assembled. Keeps the change isolated from the existing monkey-patch chain.
+- **Con**: Common identifiers (e.g. `e`, `data`, `result`) can produce false negatives
+  (unrelated findings pass the intersection test). Identifier extraction is heuristic,
+  not AST-based. Does not detect cross-file side-effects.
+
+### Option 3 — Embedding similarity search
+Embed all findings and retrieve top-k relevant code chunks via vector search.
+
+- **Pro**: Higher recall for semantically related code.
+- **Con**: Requires a persistent vector store and an embedding model call per review.
+  Adds latency on a per-finding basis. Disproportionate operational overhead for a
+  post-hoc validation step on a single-container deployment. Out of scope for M1.x.
+
+### Option 4 — LLM sub-call with full file context
+For each finding, fetch the full file and ask a sub-LLM to validate relevance.
+
+- **Pro**: Higher per-finding precision than heuristic intersection.
+- **Con**: Multiplies token cost and latency per review. Introduces a new failure cascade
+  (sub-call errors propagate into the review result). Does not inherently handle multi-file
+  relationships, which is the primary motivating problem.
+
+---
+
+## Decision
+
+**Option 2: diff-scope intersection on `+` lines only.**
+
+A new `argus_code_filter.py` module will:
+1. Extract referenced identifiers from each finding's text (file-path regex + word-boundary
+   heuristics for function/class names — no AST parsing).
+2. Build a "touched identifier set" from `+` diff lines (changed file paths + tokens
+   matching identifier patterns).
+3. Suppress findings where the referenced identifier has zero overlap with the touched set.
+4. Log suppressed findings: `[Argus] finding suppressed: no diff intersection`.
+
+The filter is called as a standalone pass after findings are generated and before they are
+assembled into the review body. It does **not** touch the inline comment assembly, footer
+counts, or review body builder — those remain unchanged. The suppression list is passed as
+a filtered finding set.
+
+**Implementation estimate**: ~100–150 lines in `argus_code_filter.py` + ~5 lines of call
+site wiring in `patch_suggestion_format.py`. Not ~50 lines — the extraction + set-build
+logic is non-trivial.
+
+---
+
+## Consequences
+
+**Positive**
+- Reduces false-positive rate for findings referencing code unrelated to the change.
+- Zero change to the review prompt, LLM call, or monkey-patch chain structure.
+- Isolated in a new module — easy to disable if the heuristic proves too aggressive.
+
+**Negative / Risks**
+- **False negatives for suppression**: short or common identifiers (single letters, generic
+  names) will match incidentally, allowing unrelated findings through. Acceptable at this
+  stage; measure false-negative rate after first 10 reviews.
+- **Identifier collision**: if a finding mentions `e` or `data`, intersection will always
+  be non-empty. Mitigate by requiring minimum identifier length (≥4 chars) in the filter.
+- **Maintainability**: the existing patch chain in `patch_suggestion_format.py` already
+  layers `apply_patch()`, `patched_run()`, incremental filtering, deduplication, and
+  doc-PR suppression. Adding another module increases cognitive load. Keep `argus_code_filter.py`
+  self-contained with clear input/output types to limit coupling.
+
+**Out of scope for this ADR**
+- Import-graph traversal (transitive call sites)
+- Embedding-based retrieval (Option 3)
+- Sub-LLM validation (Option 4)
+- AST-based identifier extraction
+
+---
+
+## References
+
+- Issue: 392fyc/Argus#9
+- M1 merged: PR #7 (narrow ESCALATE), PR #11 (nit-loop deadlock fix)  
+- M2 next: 392fyc/Argus#5 (structured event schema)
+- `patch_suggestion_format.py`: existing diff-mapping logic at lines 1194–1201

--- a/docs/self-check-setup.md
+++ b/docs/self-check-setup.md
@@ -93,12 +93,22 @@ export GH_TOKEN=ghp_...            # GitHub token (issues:write)
 SELF_CHECK_DRY_RUN=1 bash scripts/run_self_check.sh
 ```
 
+**Direct Python mode** (bypass Codex — workaround for [openai/codex#13103](https://github.com/openai/codex/issues/13103) WebSocket auth bug):
+
+```bash
+USE_DIRECT_PYTHON=1 bash scripts/run_self_check.sh
+```
+
+> In this mode `OPENAI_API_KEY` is not required; only `GH_TOKEN` and the events file.
+> Use this when Codex CLI connectivity is broken but the container + Python path is working.
+
 ---
 
 ### Plan C — Claude Code + LiteLLM + ccproxy (if Codex unavailable)
 
 **When to use**: Codex CLI cannot be used (licensing, access, or quota constraints),
-and you need to run via Claude Code with an OpenAI API key as the backend model.
+and you want Claude Code to orchestrate the run while using an **OpenAI API key as
+the model backend** (reduces Anthropic subscription load).
 
 **Architecture** (all separate Docker containers, connected via Docker network):
 
@@ -122,7 +132,7 @@ docker run -d --name litellm -p 4000:4000 \
 **ccproxy + Claude Code** (custom container — see ccproxy docs):
 - Source: https://github.com/starbased-co/ccproxy
 - Install: `uv tool install claude-ccproxy --with 'litellm[proxy]'`
-- Set: `ANTHROPIC_BASE_URL=http://litellm:4000`
+- Set: `ANTHROPIC_BASE_URL=http://ccproxy:4000` (Claude Code → ccproxy → LiteLLM → OpenAI)
 
 `scripts/litellm_config.yaml` contains the model routing config for this scenario.
 

--- a/docs/self-check-setup.md
+++ b/docs/self-check-setup.md
@@ -1,0 +1,221 @@
+# Argus Self-Check Setup
+
+Argus M3 self-check agent runs a periodic log analysis and auto-files GitHub Issues
+for detected problems. It consumes structured events produced by M2 (`argus_events.py`).
+
+## Architecture
+
+```
+events.jsonl (M2 sink)
+    │
+    ▼
+argus_log_analyzer.py  ── detects problem clusters
+    │
+    ▼
+argus_issue_formatter.py ── formats GitHub Issue bodies
+    │
+    ▼
+argus_self_check.py  ── deduplicates + calls gh issue create
+    │
+    ▼
+GitHub Issues (label: source:self-check)
+```
+
+## Deployment options
+
+### Plan A — GitHub Actions + Codex CLI (recommended)
+
+**When to use**: Argus repo has access to an OpenAI API key via repository secrets.
+
+**How it works**: `openai/codex-action@v1` runs `argus_self_check.py` inside a
+constrained Codex CLI session every 3 days.
+
+**Setup**:
+
+1. Add repository secret: `OPENAI_API_KEY`
+   - `GITHUB_TOKEN` is provided automatically by GitHub Actions (no manual secret needed)
+   - The workflow grants `issues: write` permission so `${{ secrets.GITHUB_TOKEN }}` can file Issues
+2. (Optional) Add repository variables:
+   - `SELF_CHECK_DAYS` — analysis window days (default: 3)
+   - `SELF_CHECK_MAX` — max Issues per run (default: 5)
+   - `ARGUS_EVENTS_PATH` — events sink path (default: `/var/log/argus/events.jsonl`)
+3. The workflow `.github/workflows/self-check.yml` fires automatically on schedule.
+
+**Manual trigger**: GitHub UI → Actions → "Argus self-check" → Run workflow.
+
+**Pause**: Set repository variable `SELF_CHECK_DISABLED=1`.
+
+---
+
+### Plan B — NAS cron via Codex CLI Docker container
+
+**When to use**: The NAS can access the events sink directly, or you want a fully
+on-premises scheduled run without GitHub Actions.
+
+**How it works**: A custom Docker container bundles Codex CLI + Python + gh CLI.
+NAS cron calls `docker run` every 3 days; Codex uses `OPENAI_API_KEY` directly —
+no LiteLLM or Claude Code proxy needed.
+
+> **Why Docker?** All CLIs (Codex, Claude Code, LiteLLM, ccproxy) run in isolated
+> containers — injecting them into the Argus Python container would add Node.js and
+> inflate the image. Container Station (QNAP Docker) supports this natively.
+
+**Build the container (once)**:
+
+```bash
+# From Argus repo root on the NAS:
+docker build -f scripts/Dockerfile.codex -t argus-selfcheck .
+```
+
+**Required environment variables** (set in NAS shell profile or cron env):
+
+```bash
+export OPENAI_API_KEY=sk-...       # OpenAI API key (used by Codex directly)
+export GH_TOKEN=ghp_...            # GitHub token (issues:write)
+```
+
+**NAS cron entry** (every 3 days at 02:17 local time):
+
+```cron
+17 2 * * *  OPENAI_API_KEY=sk-... GH_TOKEN=ghp_... /path/to/argus/scripts/run_self_check.sh >> /var/log/argus/self-check.log 2>&1
+```
+
+> The script's interval gate handles pacing (starts at 3 days, adapts up to 7).
+> Running the cron daily ensures the gate fires on the correct day.
+
+**Pause**: `touch /var/log/argus/.self-check-disabled`
+
+**Resume**: `rm /var/log/argus/.self-check-disabled`
+
+**Dry run (preview only)**:
+
+```bash
+SELF_CHECK_DRY_RUN=1 bash scripts/run_self_check.sh
+```
+
+---
+
+### Plan C — Claude Code + LiteLLM + ccproxy (if Codex unavailable)
+
+**When to use**: Codex CLI cannot be used (licensing, access, or quota constraints),
+and you need to run via Claude Code with an OpenAI API key as the backend model.
+
+**Architecture** (all separate Docker containers, connected via Docker network):
+
+```
+Claude Code container
+  → ANTHROPIC_BASE_URL=http://ccproxy:4000
+  → ccproxy container (starbased-co/ccproxy)
+  → LiteLLM container (ghcr.io/berriai/litellm:main-stable)
+  → OpenAI API
+```
+
+**LiteLLM container**:
+```bash
+docker run -d --name litellm -p 4000:4000 \
+  -e OPENAI_API_KEY="$OPENAI_API_KEY" \
+  -v "$(pwd)/scripts/litellm_config.yaml:/app/config.yaml" \
+  ghcr.io/berriai/litellm:main-stable \
+  --config /app/config.yaml
+```
+
+**ccproxy + Claude Code** (custom container — see ccproxy docs):
+- Source: https://github.com/starbased-co/ccproxy
+- Install: `uv tool install claude-ccproxy --with 'litellm[proxy]'`
+- Set: `ANTHROPIC_BASE_URL=http://litellm:4000`
+
+`scripts/litellm_config.yaml` contains the model routing config for this scenario.
+
+---
+
+## Manual invocation (ad-hoc)
+
+Without any agent runner — Python only:
+
+```bash
+# Preview
+python argus_self_check.py --days 3 --dry-run
+
+# File issues
+python argus_self_check.py --days 3
+
+# Custom window
+python argus_self_check.py --days 7 --max-issues 3 --sink-path /custom/path.jsonl
+```
+
+---
+
+## Adaptive scheduling (Plan B)
+
+`run_self_check.sh` implements adaptive scheduling so quiet periods reduce check
+frequency automatically.
+
+**Behavior:**
+
+| Run outcome | Exit code | Interval change |
+|-------------|-----------|-----------------|
+| No issues filed | 0 | `interval += 1 day` (max 7) |
+| Issues filed | 2 | reset to 3 days |
+| Error | other | unchanged |
+
+**Progression example** (all quiet runs):
+
+```
+Run 1: interval=3 → Run 2 in 4 days
+Run 2: interval=4 → Run 3 in 5 days
+Run 3: interval=5 → Run 4 in 6 days
+Run 4: interval=6 → Run 5 in 7 days  ← stabilises at max
+```
+
+**State file:** `${ARGUS_STATE_FILE}` (default: `/var/log/argus/self-check-state.json`)
+
+```json
+{"interval_days": 5, "last_run": "2026-04-12"}
+```
+
+**NAS cron** should be set to **daily** (not `*/3`) so the interval gate inside the
+script controls pacing:
+
+```cron
+17 2 * * *  OPENAI_API_KEY=sk-... GH_TOKEN=ghp_... /path/to/argus/scripts/run_self_check.sh >> /var/log/argus/self-check.log 2>&1
+```
+
+**Reset to 3-day interval manually:**
+
+```bash
+echo '{"interval_days": 3, "last_run": ""}' > /var/log/argus/self-check-state.json
+```
+
+**Plan A note:** GitHub Actions cron is static YAML — adaptive scheduling is not
+available in Plan A. To change the interval, update the `schedule.cron` field in
+`.github/workflows/self-check.yml` or configure `SELF_CHECK_DAYS` and re-trigger
+manually via `workflow_dispatch`.
+
+---
+
+## Deduplication
+
+Each problem cluster has a stable `signature` (16-char SHA-256 prefix of `type:title`).
+Before filing, the self-check searches for open Issues with `sig:<signature>` in the
+title. If found, the cluster is skipped.
+
+To reset deduplication for a cluster: close or label its existing Issue as `wontfix`.
+
+---
+
+## Filed Issue format
+
+Every auto-filed Issue:
+- Title: `[self-check] <emoji> <description> — sig:<signature>`
+- Labels: `source:self-check`, `type:bug` or `type:analysis`, `priority:p0–p2`
+- Body: observed evidence (facts) + UNVERIFIED hypothesis + suggested next step
+
+---
+
+## Safeguards
+
+- Agent MUST NOT modify source files, configs, or deploy files
+- Agent only files Issues to `392fyc/Argus`
+- Max 5 Issues per run (configurable)
+- All hypotheses labeled `UNVERIFIED` in the Issue body
+- Human review required before any fix is implemented

--- a/entrypoint-guard.py
+++ b/entrypoint-guard.py
@@ -287,12 +287,18 @@ def _handle_reply_to_argus(body, sender):
             if verdict == "ACCEPT":
                 _reply_to_thread(auth_h, repo_full, pr_number, first_db_id,
                                  f"✅ Acknowledged — {reason}")
-                _resolve_thread(auth_h, t["id"])
-                print(f"[Argus] Reply accepted: {thread_path} → resolved")
+                resolved = _resolve_thread(auth_h, t["id"])
+                print(f"[Argus] Reply accepted: {thread_path} → "
+                      f"{'resolved' if resolved else 'resolve failed'}")
                 emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
                              verdict="ACCEPT", thread_path=thread_path, reason=reason)
-                emitter.emit(EventType.THREAD_RESOLVED, pr_number=pr_number, repo=repo_full,
-                             thread_path=thread_path)
+                if resolved:
+                    emitter.emit(EventType.THREAD_RESOLVED, pr_number=pr_number, repo=repo_full,
+                                 thread_path=thread_path)
+                else:
+                    emitter.emit(EventType.ERROR, pr_number=pr_number, repo=repo_full,
+                                 message=f"_resolve_thread failed for {thread_path}",
+                                 thread_path=thread_path)
             elif verdict == "REJECT":
                 _reply_to_thread(auth_h, repo_full, pr_number, first_db_id,
                                  f"❓ Follow-up — {reason}")

--- a/entrypoint-guard.py
+++ b/entrypoint-guard.py
@@ -14,6 +14,8 @@ import json
 import os
 import re
 
+from argus_events import emitter, EventType
+
 _raw = os.environ.get("ARGUS_ALLOWED_USERS", "").strip()
 ALLOWED_USERS: set = set()
 if _raw:
@@ -68,6 +70,7 @@ class ArgusGuardMiddleware:
         is_self_bot = actor and actor.lower() == "argus-review[bot]"
         if not is_self_bot and actor and actor.lower() not in ALLOWED_USERS:
             print(f"[Argus Guard] BLOCKED: '{actor}' not in whitelist")
+            emitter.emit(EventType.REQUEST_BLOCKED, actor=actor)
             resp = json.dumps({"status": "skipped", "reason": f"user '{actor}' not in whitelist"}).encode()
             await send({"type": "http.response.start", "status": 200,
                         "headers": [[b"content-type", b"application/json"],
@@ -192,6 +195,8 @@ def _handle_reply_to_argus(body, sender):
         token = _get_app_installation_token()
         if not token:
             print("[Argus] No app installation token — cannot reply as bot")
+            emitter.emit(EventType.ERROR, pr_number=pr_number, repo=repo_full,
+                         message="no app installation token")
             return
 
         auth_h = {"Authorization": f"Bearer {token}",
@@ -253,6 +258,8 @@ def _handle_reply_to_argus(body, sender):
 
             if argus_judgment_count >= MAX_REPLY_ROUNDS:
                 print(f"[Argus] Reply judgment: max rounds reached for {t.get('path')}")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="max_rounds_reached", thread_path=t.get("path"))
                 return
 
             # Get original finding (first Argus comment)
@@ -273,6 +280,8 @@ def _handle_reply_to_argus(body, sender):
             # Never post replies for LLM errors — log and return silently
             if verdict == "ESCALATE" and "LLM error" in reason:
                 print(f"[Argus] Reply judgment LLM failed for {thread_path}: {reason}")
+                emitter.emit(EventType.ERROR, pr_number=pr_number, repo=repo_full,
+                             message=f"LLM failed: {reason}", thread_path=thread_path)
                 return
 
             if verdict == "ACCEPT":
@@ -280,19 +289,28 @@ def _handle_reply_to_argus(body, sender):
                                  f"✅ Acknowledged — {reason}")
                 _resolve_thread(auth_h, t["id"])
                 print(f"[Argus] Reply accepted: {thread_path} → resolved")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="ACCEPT", thread_path=thread_path, reason=reason)
+                emitter.emit(EventType.THREAD_RESOLVED, pr_number=pr_number, repo=repo_full,
+                             thread_path=thread_path)
             elif verdict == "REJECT":
                 _reply_to_thread(auth_h, repo_full, pr_number, first_db_id,
                                  f"❓ Follow-up — {reason}")
                 print(f"[Argus] Reply rejected: {thread_path} → follow-up")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="REJECT", thread_path=thread_path, reason=reason)
             else:  # ESCALATE (genuine, not LLM error)
                 _reply_to_thread(auth_h, repo_full, pr_number, first_db_id,
                                  f"⚠️ Escalated — {reason}\n\n"
                                  f"*This thread requires human reviewer input.*")
                 print(f"[Argus] Reply escalated: {thread_path}")
+                emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=pr_number, repo=repo_full,
+                             verdict="ESCALATE", thread_path=thread_path, reason=reason)
             return  # Only handle one thread per comment
 
     except Exception as e:
         print(f"[Argus] Reply handler error: {e}")
+        emitter.emit(EventType.ERROR, message=f"reply handler: {e}")
 
 
 def _patch_mention_handler():
@@ -330,6 +348,11 @@ def _patch_mention_handler():
                         print(f"[Argus] @mention rewritten: "
                               f"'{comment_body[:60]}' → '{rewritten[:60]}'")
                         body["comment"]["body"] = rewritten
+                        _pr_num = body.get("pull_request", {}).get("number")
+                        _repo = body.get("repository", {}).get("full_name")
+                        emitter.emit(EventType.MENTION_REWRITTEN, pr_number=_pr_num,
+                                     repo=_repo, original=comment_body[:60],
+                                     rewritten=rewritten[:60])
 
             return await original_handle(body, event, sender, sender_id,
                                          action, log_context, agent)

--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -9,6 +9,8 @@ Thread auto-resolve: resolve outdated threads after push
 Reference: CodeRabbit PR review format (2026)
 """
 
+from argus_events import emitter, EventType
+
 # ── Severity mapping ──────────────────────────────────────────────
 
 SEVERITY_MAP = {
@@ -1171,6 +1173,9 @@ def apply_patch():
             if not review_body:
                 return result
 
+            _repo = getattr(getattr(self.git_provider, 'repo', None), 'full_name', None)
+            emitter.emit(EventType.REVIEW_STARTED, pr_number=pr_number, repo=_repo)
+
             # Parse findings from prediction
             findings = []
             inline_comments = []
@@ -1372,6 +1377,8 @@ def apply_patch():
                 )
                 n = len(inline_comments)
                 print(f"[Argus] Posted {event} review ({n} inline, iteration {iteration})")
+                emitter.emit(EventType.FINDING_POSTED, pr_number=pr_number, repo=_repo,
+                             finding_count=n, review_event=event, iteration=iteration)
             except Exception as e:
                 print(f"[Argus] Unified review failed ({e}), fallback to COMMENT")
                 try:

--- a/scripts/Dockerfile.codex
+++ b/scripts/Dockerfile.codex
@@ -1,0 +1,40 @@
+# Codex CLI container for Argus self-check (Plan B — NAS cron)
+#
+# Build:
+#   docker build -f scripts/Dockerfile.codex -t argus-selfcheck .
+#
+# Based on node:22-slim (Codex CLI requirement) with Python 3 and gh CLI added.
+# Source: https://github.com/openai/codex (Node.js 22 required)
+
+FROM node:22-slim
+
+# Install Python 3, pip, and gh CLI prerequisites
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install gh CLI (GitHub's official CLI)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Codex CLI globally
+RUN npm install -g @openai/codex
+
+# Install Python dependencies for argus_self_check.py
+# (argus_events, argus_extractor, argus_log_analyzer, argus_issue_formatter are
+#  local modules — no pip install needed; only stdlib used)
+# Install requests in case argus modules need it at import time
+RUN pip3 install --no-cache-dir requests --break-system-packages || \
+    pip3 install --no-cache-dir requests
+
+WORKDIR /workspace
+
+# Default: print help (actual command passed at docker run time)
+CMD ["codex", "--help"]

--- a/scripts/litellm_config.yaml
+++ b/scripts/litellm_config.yaml
@@ -47,4 +47,4 @@ litellm_settings:
   request_timeout: 600
 
 general_settings:
-  master_key: "litellm-argus-self-check"  # internal only — not exposed externally
+  master_key: "${LITELLM_MASTER_KEY:-litellm-argus-self-check}"  # override via env for production

--- a/scripts/litellm_config.yaml
+++ b/scripts/litellm_config.yaml
@@ -1,0 +1,50 @@
+# LiteLLM proxy config — Plan B fallback for Argus self-check
+#
+# Routes OpenAI API key requests through LiteLLM so Claude Code can use
+# OpenAI models (gpt-4o / gpt-4o-mini) via the Anthropic-compatible API surface.
+#
+# Start server:
+#   litellm --config scripts/litellm_config.yaml
+#
+# Default listen address: http://localhost:4000
+#
+# Required env:
+#   OPENAI_API_KEY — OpenAI API key available in the NAS environment
+
+model_list:
+  # Claude Code sends requests with these Anthropic model IDs.
+  # LiteLLM routes them to OpenAI equivalents via the local OpenAI API key.
+
+  - model_name: claude-sonnet-4-5
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: "os.environ/OPENAI_API_KEY"
+
+  - model_name: claude-sonnet-4-6
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: "os.environ/OPENAI_API_KEY"
+
+  - model_name: claude-opus-4-5
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: "os.environ/OPENAI_API_KEY"
+
+  - model_name: claude-opus-4-6
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: "os.environ/OPENAI_API_KEY"
+
+  - model_name: claude-haiku-4-5
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: "os.environ/OPENAI_API_KEY"
+
+litellm_settings:
+  # Drop unknown parameters that Anthropic SDK sends but OpenAI doesn't accept
+  drop_params: true
+  # Increase timeout for long-running agent tasks
+  request_timeout: 600
+
+general_settings:
+  master_key: "litellm-argus-self-check"  # internal only — not exposed externally

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Argus self-check runner — Plan B: NAS cron via Codex CLI Docker container
+#
+# Runs the self-check agent using Codex CLI in an isolated Docker container.
+# No LiteLLM or Claude Code required; Codex uses OPENAI_API_KEY directly.
+#
+# Usage (NAS cron, daily check with adaptive interval gate):
+#   17 2 * * *  /path/to/argus/scripts/run_self_check.sh >> /var/log/argus/self-check.log 2>&1
+#
+# Prerequisites (build once on NAS):
+#   docker build -f scripts/Dockerfile.codex -t argus-selfcheck .
+#
+# Required env (set in NAS shell profile or cron env):
+#   OPENAI_API_KEY    — OpenAI API key (Codex CLI uses this directly)
+#   GH_TOKEN          — GitHub token with issues:write scope
+#   ARGUS_REPO_DIR    — absolute path to Argus repo on NAS (default: directory of this script's parent)
+#
+# Optional:
+#   SELF_CHECK_DAYS         — analysis window in days (default: 3)
+#   SELF_CHECK_MAX_ISSUES   — cap on Issues per run (default: 5)
+#   SELF_CHECK_DRY_RUN      — set to 1 to preview without filing
+#   ARGUS_EVENTS_PATH       — path to events.jsonl inside container (default: /var/log/argus/events.jsonl)
+#   EVENTS_HOST_PATH        — host path to events.jsonl (default: /var/log/argus/events.jsonl)
+#   CODEX_IMAGE             — Docker image name (default: argus-selfcheck)
+#   ARGUS_STATE_FILE        — path to adaptive scheduling state JSON
+#                             (default: /var/log/argus/self-check-state.json)
+#
+# Adaptive scheduling:
+#   On a quiet run (exit 0, no issues filed): interval += 1 day, max 7 days.
+#   On a finding run (exit 2, issues filed):  interval resets to 3 days.
+#   On error (any other exit code):           interval unchanged.
+#   Set NAS cron to run daily; the interval gate inside this script handles pacing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${ARGUS_REPO_DIR:-$(dirname "$SCRIPT_DIR")}"
+PAUSE_FLAG="/var/log/argus/.self-check-disabled"
+
+DAYS="${SELF_CHECK_DAYS:-3}"
+MAX_ISSUES="${SELF_CHECK_MAX_ISSUES:-5}"
+DRY_RUN="${SELF_CHECK_DRY_RUN:-0}"
+EVENTS_HOST="${EVENTS_HOST_PATH:-/var/log/argus/events.jsonl}"
+EVENTS_CONTAINER="${ARGUS_EVENTS_PATH:-/var/log/argus/events.jsonl}"
+IMAGE="${CODEX_IMAGE:-argus-selfcheck}"
+STATE_FILE="${ARGUS_STATE_FILE:-/var/log/argus/self-check-state.json}"
+
+MIN_INTERVAL=3
+MAX_INTERVAL=7
+
+# ── Pause check ───────────────────────────────────────────────────────────────
+if [ -f "$PAUSE_FLAG" ]; then
+  echo "[self-check] Paused ($PAUSE_FLAG exists). Remove to re-enable."
+  exit 0
+fi
+
+# ── Verify events file ────────────────────────────────────────────────────────
+if [ ! -f "$EVENTS_HOST" ]; then
+  echo "[self-check] WARNING: events file not found at $EVENTS_HOST — skipping run."
+  echo "[self-check] Set EVENTS_HOST_PATH to the correct path and retry."
+  exit 0
+fi
+
+# ── Read adaptive scheduling state ───────────────────────────────────────────
+CURRENT_INTERVAL=$MIN_INTERVAL
+LAST_RUN=""
+if [ -f "$STATE_FILE" ]; then
+  CURRENT_INTERVAL=$(python3 - <<PYEOF
+import json, sys
+try:
+    d = json.load(open("$STATE_FILE"))
+    print(int(d.get("interval_days", $MIN_INTERVAL)))
+except Exception:
+    print($MIN_INTERVAL)
+PYEOF
+)
+  LAST_RUN=$(python3 - <<PYEOF
+import json, sys
+try:
+    d = json.load(open("$STATE_FILE"))
+    print(d.get("last_run", ""))
+except Exception:
+    print("")
+PYEOF
+)
+fi
+
+# ── Interval gate ─────────────────────────────────────────────────────────────
+if [ -n "$LAST_RUN" ]; then
+  DAYS_SINCE=$(python3 - <<PYEOF
+from datetime import date
+try:
+    delta = date.today() - date.fromisoformat("$LAST_RUN")
+    print(delta.days)
+except Exception:
+    print(999)
+PYEOF
+)
+  if [ "$DAYS_SINCE" -lt "$CURRENT_INTERVAL" ]; then
+    echo "[self-check] Skipping: ${DAYS_SINCE} day(s) since last run; interval is ${CURRENT_INTERVAL} days."
+    exit 0
+  fi
+fi
+
+echo "[self-check] Starting at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "[self-check] Window: ${DAYS} days | max-issues: ${MAX_ISSUES} | dry-run: ${DRY_RUN} | interval: ${CURRENT_INTERVAL} days"
+
+# ── Build Codex args ──────────────────────────────────────────────────────────
+EXTRA_ARGS=""
+[ "$DRY_RUN" = "1" ] && EXTRA_ARGS="--dry-run"
+
+PROMPT="Run the Argus self-check: execute 'python argus_self_check.py --days ${DAYS} --max-issues ${MAX_ISSUES} ${EXTRA_ARGS}' and report results. Do NOT modify any source files, configs, or deploy files."
+
+# ── Run Codex in container ────────────────────────────────────────────────────
+DOCKER_EXIT=0
+docker run --rm \
+  --name "argus-self-check-$$" \
+  -e "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+  -e "GH_TOKEN=${GH_TOKEN:-}" \
+  -e "ARGUS_EVENTS_PATH=${EVENTS_CONTAINER}" \
+  -v "${REPO_DIR}:/workspace:ro" \
+  -v "${EVENTS_HOST}:${EVENTS_CONTAINER}:ro" \
+  -w /workspace \
+  "${IMAGE}" \
+  codex exec --approval-mode full-auto "${PROMPT}" || DOCKER_EXIT=$?
+
+# ── Update adaptive schedule state ───────────────────────────────────────────
+TODAY=$(date +%Y-%m-%d)
+if [ $DOCKER_EXIT -eq 0 ]; then
+  # Quiet run: no issues filed — gradually widen interval
+  NEW_INTERVAL=$(python3 -c "print(min($CURRENT_INTERVAL + 1, $MAX_INTERVAL))")
+  echo "[self-check] Quiet run. Interval: ${CURRENT_INTERVAL} → ${NEW_INTERVAL} days."
+elif [ $DOCKER_EXIT -eq 2 ]; then
+  # Findings detected: reset to minimum interval
+  NEW_INTERVAL=$MIN_INTERVAL
+  echo "[self-check] Findings detected (exit 2). Interval reset to ${MIN_INTERVAL} days."
+else
+  # Error: keep current interval, do not advance last_run date
+  echo "[self-check] Run error (exit ${DOCKER_EXIT}). Interval unchanged (${CURRENT_INTERVAL} days)."
+  echo "[self-check] Completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  exit $DOCKER_EXIT
+fi
+
+# Ensure state directory exists
+mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true
+
+python3 - <<PYEOF
+import json
+state = {"interval_days": $NEW_INTERVAL, "last_run": "$TODAY"}
+with open("$STATE_FILE", "w") as f:
+    json.dump(state, f)
+print(f"[self-check] State saved: interval={state['interval_days']} days, last_run={state['last_run']}")
+PYEOF
+
+echo "[self-check] Completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+exit $DOCKER_EXIT

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -122,7 +122,7 @@ $DOCKER_CMD run --rm \
   -v "${EVENTS_HOST}:${EVENTS_CONTAINER}:ro" \
   -w /workspace \
   "${IMAGE}" \
-  codex exec --full-auto "${PROMPT}" || DOCKER_EXIT=$?
+  codex exec --full-auto --skip-git-repo-check "${PROMPT}" || DOCKER_EXIT=$?
 
 # ── Update adaptive schedule state ───────────────────────────────────────────
 TODAY=$(date +%Y-%m-%d)

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -81,40 +81,21 @@ if [ ! -f "$EVENTS_HOST" ]; then
 fi
 
 # ── Read adaptive scheduling state ───────────────────────────────────────────
+# Pure-shell JSON parsing (no python3 required on NAS host).
 CURRENT_INTERVAL=$MIN_INTERVAL
 LAST_RUN=""
 if [ -f "$STATE_FILE" ]; then
-  CURRENT_INTERVAL=$(python3 - <<PYEOF
-import json, sys
-try:
-    d = json.load(open("$STATE_FILE"))
-    print(int(d.get("interval_days", $MIN_INTERVAL)))
-except Exception:
-    print($MIN_INTERVAL)
-PYEOF
-)
-  LAST_RUN=$(python3 - <<PYEOF
-import json, sys
-try:
-    d = json.load(open("$STATE_FILE"))
-    print(d.get("last_run", ""))
-except Exception:
-    print("")
-PYEOF
-)
+  _iv=$(grep -o '"interval_days"[[:space:]]*:[[:space:]]*[0-9]*' "$STATE_FILE" 2>/dev/null | grep -o '[0-9]*$')
+  [ -n "$_iv" ] && CURRENT_INTERVAL="$_iv"
+  LAST_RUN=$(grep -o '"last_run"[[:space:]]*:[[:space:]]*"[^"]*"' "$STATE_FILE" 2>/dev/null \
+             | sed 's/.*"\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\)".*/\1/')
 fi
 
 # ── Interval gate ─────────────────────────────────────────────────────────────
 if [ -n "$LAST_RUN" ]; then
-  DAYS_SINCE=$(python3 - <<PYEOF
-from datetime import date
-try:
-    delta = date.today() - date.fromisoformat("$LAST_RUN")
-    print(delta.days)
-except Exception:
-    print(999)
-PYEOF
-)
+  _now=$(date +%s)
+  _last=$(date -d "$LAST_RUN" +%s 2>/dev/null || echo 0)
+  DAYS_SINCE=$(( (_now - _last) / 86400 ))
   if [ "$DAYS_SINCE" -lt "$CURRENT_INTERVAL" ]; then
     echo "[self-check] Skipping: ${DAYS_SINCE} day(s) since last run; interval is ${CURRENT_INTERVAL} days."
     exit 0
@@ -147,7 +128,8 @@ $DOCKER_CMD run --rm \
 TODAY=$(date +%Y-%m-%d)
 if [ $DOCKER_EXIT -eq 0 ]; then
   # Quiet run: no issues filed — gradually widen interval
-  NEW_INTERVAL=$(python3 -c "print(min($CURRENT_INTERVAL + 1, $MAX_INTERVAL))")
+  NEW_INTERVAL=$(( CURRENT_INTERVAL + 1 ))
+  [ "$NEW_INTERVAL" -gt "$MAX_INTERVAL" ] && NEW_INTERVAL=$MAX_INTERVAL
   echo "[self-check] Quiet run. Interval: ${CURRENT_INTERVAL} → ${NEW_INTERVAL} days."
 elif [ $DOCKER_EXIT -eq 2 ]; then
   # Findings detected: reset to minimum interval
@@ -163,13 +145,8 @@ fi
 # Ensure state directory exists
 mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true
 
-python3 - <<PYEOF
-import json
-state = {"interval_days": $NEW_INTERVAL, "last_run": "$TODAY"}
-with open("$STATE_FILE", "w") as f:
-    json.dump(state, f)
-print(f"[self-check] State saved: interval={state['interval_days']} days, last_run={state['last_run']}")
-PYEOF
+printf '{"interval_days": %d, "last_run": "%s"}\n' "$NEW_INTERVAL" "$TODAY" > "$STATE_FILE"
+echo "[self-check] State saved: interval=${NEW_INTERVAL} days, last_run=${TODAY}"
 
 echo "[self-check] Completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 exit $DOCKER_EXIT

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -76,7 +76,7 @@ if [ -f "$_SECRETS" ]; then
     OPENAI_API_KEY=$(grep -A5 '^\[openai\]' "$_SECRETS" | grep '^key' | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/')
   fi
   if [ -z "${GH_TOKEN:-}" ]; then
-    GH_TOKEN=$(grep -A5 '^\[github\]' "$_SECRETS" | grep '^user_token' | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/')
+    GH_TOKEN=$(grep '^user_token' "$_SECRETS" | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/')
   fi
 fi
 

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -19,6 +19,8 @@
 #   SELF_CHECK_DAYS         — analysis window in days (default: 3)
 #   SELF_CHECK_MAX_ISSUES   — cap on Issues per run (default: 5)
 #   SELF_CHECK_DRY_RUN      — set to 1 to preview without filing
+#   USE_DIRECT_PYTHON       — set to 1 to skip Codex and run python3 directly in the container
+#                             (workaround for Codex CLI WebSocket/auth issues; openai/codex#13103)
 #   ARGUS_EVENTS_PATH       — path to events.jsonl inside container (default: /var/log/argus/events.jsonl)
 #   EVENTS_HOST_PATH        — host path to events.jsonl (default: /var/log/argus/events.jsonl)
 #   CODEX_IMAGE             — Docker image name (default: argus-selfcheck)
@@ -40,6 +42,7 @@ PAUSE_FLAG="/var/log/argus/.self-check-disabled"
 DAYS="${SELF_CHECK_DAYS:-3}"
 MAX_ISSUES="${SELF_CHECK_MAX_ISSUES:-5}"
 DRY_RUN="${SELF_CHECK_DRY_RUN:-0}"
+DIRECT_PYTHON="${USE_DIRECT_PYTHON:-0}"
 EVENTS_HOST="${EVENTS_HOST_PATH:-/var/log/argus/events.jsonl}"
 EVENTS_CONTAINER="${ARGUS_EVENTS_PATH:-/var/log/argus/events.jsonl}"
 IMAGE="${CODEX_IMAGE:-argus-selfcheck}"
@@ -118,24 +121,38 @@ fi
 echo "[self-check] Starting at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 echo "[self-check] Window: ${DAYS} days | max-issues: ${MAX_ISSUES} | dry-run: ${DRY_RUN} | interval: ${CURRENT_INTERVAL} days"
 
-# ── Build Codex args ──────────────────────────────────────────────────────────
+# ── Build run args ────────────────────────────────────────────────────────────
 EXTRA_ARGS=""
 [ "$DRY_RUN" = "1" ] && EXTRA_ARGS="--dry-run"
 
-PROMPT="Run the Argus self-check: execute 'python argus_self_check.py --days ${DAYS} --max-issues ${MAX_ISSUES} ${EXTRA_ARGS}' and report results. Do NOT modify any source files, configs, or deploy files."
-
-# ── Run Codex in container ────────────────────────────────────────────────────
+# ── Run self-check ────────────────────────────────────────────────────────────
 DOCKER_EXIT=0
-$DOCKER_CMD run --rm \
-  --name "argus-self-check-$$" \
-  -e "OPENAI_API_KEY=${OPENAI_API_KEY}" \
-  -e "GH_TOKEN=${GH_TOKEN:-}" \
-  -e "ARGUS_EVENTS_PATH=${EVENTS_CONTAINER}" \
-  -v "${REPO_DIR}:/workspace:ro" \
-  -v "${EVENTS_HOST}:${EVENTS_CONTAINER}:ro" \
-  -w /workspace \
-  "${IMAGE}" \
-  codex exec --full-auto --skip-git-repo-check -m "${CODEX_MODEL:-gpt-4o}" "${PROMPT}" || DOCKER_EXIT=$?
+if [ "$DIRECT_PYTHON" = "1" ]; then
+  # Direct Python mode: bypass Codex (workaround for openai/codex#13103 WebSocket auth bug)
+  # shellcheck disable=SC2086
+  $DOCKER_CMD run --rm \
+    --name "argus-self-check-$$" \
+    -e "GH_TOKEN=${GH_TOKEN:-}" \
+    -e "ARGUS_EVENTS_PATH=${EVENTS_CONTAINER}" \
+    -v "${REPO_DIR}:/workspace:ro" \
+    -v "${EVENTS_HOST}:${EVENTS_CONTAINER}:ro" \
+    -w /workspace \
+    "${IMAGE}" \
+    python3 argus_self_check.py --days "${DAYS}" --max-issues "${MAX_ISSUES}" ${EXTRA_ARGS} || DOCKER_EXIT=$?
+else
+  # Codex mode (default): LLM-orchestrated run via Codex CLI
+  PROMPT="Run the Argus self-check: execute 'python argus_self_check.py --days ${DAYS} --max-issues ${MAX_ISSUES} ${EXTRA_ARGS}' and report results. Do NOT modify any source files, configs, or deploy files."
+  $DOCKER_CMD run --rm \
+    --name "argus-self-check-$$" \
+    -e "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+    -e "GH_TOKEN=${GH_TOKEN:-}" \
+    -e "ARGUS_EVENTS_PATH=${EVENTS_CONTAINER}" \
+    -v "${REPO_DIR}:/workspace:ro" \
+    -v "${EVENTS_HOST}:${EVENTS_CONTAINER}:ro" \
+    -w /workspace \
+    "${IMAGE}" \
+    codex exec --full-auto --skip-git-repo-check -m "${CODEX_MODEL:-gpt-4o}" "${PROMPT}" || DOCKER_EXIT=$?
+fi
 
 # ── Update adaptive schedule state ───────────────────────────────────────────
 TODAY=$(date +%Y-%m-%d)

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -67,6 +67,19 @@ fi
 MIN_INTERVAL=3
 MAX_INTERVAL=7
 
+# ── Read credentials from .secrets.toml if not already in env ────────────────
+# Set ARGUS_SECRETS_FILE to reuse the existing Argus secrets (no new credentials).
+# Defaults to <repo-dir>/.secrets.toml so on-NAS runs work without extra config.
+_SECRETS="${ARGUS_SECRETS_FILE:-${REPO_DIR}/.secrets.toml}"
+if [ -f "$_SECRETS" ]; then
+  if [ -z "${OPENAI_API_KEY:-}" ]; then
+    OPENAI_API_KEY=$(grep -A5 '^\[openai\]' "$_SECRETS" | grep '^key' | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/')
+  fi
+  if [ -z "${GH_TOKEN:-}" ]; then
+    GH_TOKEN=$(grep -A5 '^\[github\]' "$_SECRETS" | grep '^user_token' | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/')
+  fi
+fi
+
 # ── Pause check ───────────────────────────────────────────────────────────────
 if [ -f "$PAUSE_FLAG" ]; then
   echo "[self-check] Paused ($PAUSE_FLAG exists). Remove to re-enable."

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -45,6 +45,25 @@ EVENTS_CONTAINER="${ARGUS_EVENTS_PATH:-/var/log/argus/events.jsonl}"
 IMAGE="${CODEX_IMAGE:-argus-selfcheck}"
 STATE_FILE="${ARGUS_STATE_FILE:-/var/log/argus/self-check-state.json}"
 
+# ── Docker environment (QNAP Container Station) ───────────────────────────────
+# QNAP does not expose Docker on the standard /var/run/docker.sock.
+# Container Station's daemon socket is used instead.
+# Override DOCKER_CMD to use a different docker binary or connection settings.
+_QNAP_DOCKER=/share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
+_QNAP_SOCK=unix:///var/run/system-docker.sock
+_DOCKER_CFG=/tmp/docker-selfcheck-$$
+
+if [ -z "${DOCKER_CMD:-}" ]; then
+  if [ -x "$_QNAP_DOCKER" ]; then
+    mkdir -p "$_DOCKER_CFG"
+    export DOCKER_CONFIG="$_DOCKER_CFG"
+    export DOCKER_HOST="${DOCKER_HOST:-$_QNAP_SOCK}"
+    DOCKER_CMD="$_QNAP_DOCKER"
+  else
+    DOCKER_CMD="docker"  # fallback: docker in PATH (non-QNAP environments)
+  fi
+fi
+
 MIN_INTERVAL=3
 MAX_INTERVAL=7
 
@@ -113,7 +132,7 @@ PROMPT="Run the Argus self-check: execute 'python argus_self_check.py --days ${D
 
 # ── Run Codex in container ────────────────────────────────────────────────────
 DOCKER_EXIT=0
-docker run --rm \
+$DOCKER_CMD run --rm \
   --name "argus-self-check-$$" \
   -e "OPENAI_API_KEY=${OPENAI_API_KEY}" \
   -e "GH_TOKEN=${GH_TOKEN:-}" \

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -135,7 +135,7 @@ $DOCKER_CMD run --rm \
   -v "${EVENTS_HOST}:${EVENTS_CONTAINER}:ro" \
   -w /workspace \
   "${IMAGE}" \
-  codex exec --full-auto --skip-git-repo-check "${PROMPT}" || DOCKER_EXIT=$?
+  codex exec --full-auto --skip-git-repo-check -m "${CODEX_MODEL:-gpt-4o}" "${PROMPT}" || DOCKER_EXIT=$?
 
 # ── Update adaptive schedule state ───────────────────────────────────────────
 TODAY=$(date +%Y-%m-%d)

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -122,7 +122,7 @@ $DOCKER_CMD run --rm \
   -v "${EVENTS_HOST}:${EVENTS_CONTAINER}:ro" \
   -w /workspace \
   "${IMAGE}" \
-  codex exec --approval-mode full-auto "${PROMPT}" || DOCKER_EXIT=$?
+  codex exec --full-auto "${PROMPT}" || DOCKER_EXIT=$?
 
 # ── Update adaptive schedule state ───────────────────────────────────────────
 TODAY=$(date +%Y-%m-%d)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,165 @@
+"""Tests for argus_events + argus_extractor (schema + round-trip)."""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from argus_events import ArgusEvent, EventType, EventEmitter
+from argus_extractor import read_events
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tmp_sink(tmp_path):
+    return str(tmp_path / "events.jsonl")
+
+
+@pytest.fixture
+def emitter(tmp_sink):
+    return EventEmitter(sink_path=tmp_sink)
+
+
+def _make_event(event_type: EventType, **kwargs) -> ArgusEvent:
+    return ArgusEvent(
+        event_type=event_type,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        pr_number=kwargs.get("pr_number", 42),
+        repo=kwargs.get("repo", "392fyc/Mercury"),
+        severity=kwargs.get("severity"),
+        payload=kwargs.get("payload", {}),
+    )
+
+
+# ── Schema tests ──────────────────────────────────────────────────────
+
+class TestArgusEventSchema:
+    def test_all_event_types_defined(self):
+        expected = {
+            "review_started", "finding_posted", "reply_classified",
+            "thread_resolved", "error", "mention_rewritten", "request_blocked",
+        }
+        assert {e.value for e in EventType} == expected
+
+    def test_to_dict_round_trip(self):
+        event = _make_event(EventType.REVIEW_STARTED, severity="Medium",
+                            payload={"iteration": 1})
+        d = event.to_dict()
+        assert d["event_type"] == "review_started"
+        assert d["pr_number"] == 42
+        assert d["payload"]["iteration"] == 1
+        restored = ArgusEvent.from_dict(d)
+        assert restored.event_type == EventType.REVIEW_STARTED
+        assert restored.pr_number == 42
+        assert restored.payload["iteration"] == 1
+
+    def test_from_dict_rejects_unknown_event_type(self):
+        d = _make_event(EventType.ERROR).to_dict()
+        d["event_type"] = "not_a_real_type"
+        with pytest.raises(ValueError):
+            ArgusEvent.from_dict(d)
+
+    @pytest.mark.parametrize("event_type", list(EventType))
+    def test_each_event_type_serializes(self, event_type):
+        event = _make_event(event_type)
+        d = event.to_dict()
+        assert d["event_type"] == event_type.value
+        restored = ArgusEvent.from_dict(d)
+        assert restored.event_type == event_type
+
+
+# ── EventEmitter tests ────────────────────────────────────────────────
+
+class TestEventEmitter:
+    def test_emit_writes_jsonline(self, emitter, tmp_sink):
+        emitter.emit(EventType.REQUEST_BLOCKED, pr_number=1, repo="r/r", actor="eve")
+        assert os.path.exists(tmp_sink)
+        with open(tmp_sink) as fh:
+            lines = [l for l in fh.read().splitlines() if l]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["event_type"] == "request_blocked"
+        assert record["payload"]["actor"] == "eve"
+
+    def test_emit_multiple_events_appends(self, emitter, tmp_sink):
+        emitter.emit(EventType.REVIEW_STARTED, pr_number=10)
+        emitter.emit(EventType.FINDING_POSTED, pr_number=10)
+        emitter.emit(EventType.ERROR, pr_number=10, message="boom")
+        with open(tmp_sink) as fh:
+            lines = [l for l in fh.read().splitlines() if l]
+        assert len(lines) == 3
+        types = [json.loads(l)["event_type"] for l in lines]
+        assert types == ["review_started", "finding_posted", "error"]
+
+    def test_emit_does_not_raise_on_bad_path(self):
+        bad_emitter = EventEmitter(sink_path="/nonexistent/deep/path/events.jsonl")
+        # Should not raise
+        bad_emitter.emit(EventType.ERROR)
+
+    def test_emit_payload_kwargs(self, emitter, tmp_sink):
+        emitter.emit(EventType.REPLY_CLASSIFIED, pr_number=5, verdict="ACCEPT",
+                     thread_path="src/foo.py")
+        with open(tmp_sink) as fh:
+            record = json.loads(fh.readline())
+        assert record["payload"]["verdict"] == "ACCEPT"
+        assert record["payload"]["thread_path"] == "src/foo.py"
+
+
+# ── Extractor round-trip tests ────────────────────────────────────────
+
+class TestReadEvents:
+    def test_empty_file_returns_empty_list(self, tmp_sink):
+        open(tmp_sink, "w").close()
+        assert read_events(sink_path=tmp_sink) == []
+
+    def test_missing_file_returns_empty_list(self, tmp_path):
+        assert read_events(sink_path=str(tmp_path / "missing.jsonl")) == []
+
+    def test_full_round_trip(self, emitter, tmp_sink):
+        emitter.emit(EventType.REVIEW_STARTED, pr_number=7, repo="392fyc/Argus",
+                     iteration=2)
+        emitter.emit(EventType.FINDING_POSTED, pr_number=7, count=3)
+        events = read_events(sink_path=tmp_sink)
+        assert len(events) == 2
+        assert events[0].event_type == EventType.REVIEW_STARTED
+        assert events[0].pr_number == 7
+        assert events[0].payload["iteration"] == 2
+        assert events[1].event_type == EventType.FINDING_POSTED
+        assert events[1].payload["count"] == 3
+
+    def test_filter_by_event_type(self, emitter, tmp_sink):
+        emitter.emit(EventType.REVIEW_STARTED, pr_number=1)
+        emitter.emit(EventType.ERROR, pr_number=1, message="oops")
+        emitter.emit(EventType.FINDING_POSTED, pr_number=1)
+        errors = read_events(sink_path=tmp_sink, event_types=[EventType.ERROR])
+        assert len(errors) == 1
+        assert errors[0].event_type == EventType.ERROR
+
+    def test_filter_by_time_range(self, emitter, tmp_sink):
+        now = datetime.now(timezone.utc)
+        # Write an event, then filter it out with a future `since`
+        emitter.emit(EventType.MENTION_REWRITTEN, pr_number=2)
+        future = now + timedelta(hours=1)
+        events = read_events(sink_path=tmp_sink, since=future)
+        assert events == []
+
+    def test_filter_since_includes_matching(self, emitter, tmp_sink):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        emitter.emit(EventType.THREAD_RESOLVED, pr_number=3)
+        events = read_events(sink_path=tmp_sink, since=past)
+        assert len(events) == 1
+
+    def test_malformed_line_skipped(self, tmp_sink):
+        with open(tmp_sink, "w") as fh:
+            fh.write('not json\n')
+            fh.write(json.dumps(ArgusEvent(
+                event_type=EventType.ERROR,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                payload={},
+            ).to_dict()) + "\n")
+        events = read_events(sink_path=tmp_sink)
+        assert len(events) == 1
+        assert events[0].event_type == EventType.ERROR

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -1,0 +1,249 @@
+"""
+Tests for M3 self-check: analyzer, formatter, orchestrator.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from argus_events import EventType, ArgusEvent
+from argus_log_analyzer import (
+    analyze,
+    ProblemCluster,
+    TYPE_ERROR_SPIKE,
+    TYPE_ESCALATE_OVERRATE,
+    TYPE_RESOLUTION_GAP,
+    TYPE_ACCESS_PATTERN,
+    TYPE_DATA_GAP,
+    SEVERITY_HIGH,
+    SEVERITY_MEDIUM,
+    SEVERITY_LOW,
+)
+from argus_issue_formatter import format_issue
+from argus_self_check import run
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _write_events(path: str, events: list[ArgusEvent]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for e in events:
+            fh.write(json.dumps(e.to_dict()) + "\n")
+
+
+def _make_event(event_type: EventType, **payload) -> ArgusEvent:
+    return ArgusEvent(
+        event_type=event_type,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        payload=payload,
+    )
+
+
+# ── TestAnalyzer ──────────────────────────────────────────────────────────────
+
+class TestAnalyzer:
+    def test_empty_sink_returns_data_gap(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        _write_events(sink, [])
+        clusters = analyze(sink_path=sink)
+        assert len(clusters) == 1
+        assert clusters[0].type == TYPE_DATA_GAP
+
+    def test_no_sink_file_returns_empty(self, tmp_path):
+        """Missing sink = infrastructure/config issue; no cluster filed."""
+        sink = str(tmp_path / "nonexistent.jsonl")
+        clusters = analyze(sink_path=sink)
+        assert clusters == []
+
+    def test_error_spike_threshold(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = [
+            _make_event(EventType.ERROR, message=f"err {i}") for i in range(4)
+        ]
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        types = [c.type for c in clusters]
+        assert TYPE_ERROR_SPIKE in types
+
+    def test_below_error_threshold_no_spike(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = [
+            _make_event(EventType.ERROR, message="err") for _ in range(2)
+        ]
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        types = [c.type for c in clusters]
+        assert TYPE_ERROR_SPIKE not in types
+
+    def test_escalate_overrate(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = (
+            [_make_event(EventType.REPLY_CLASSIFIED, verdict="ESCALATE", reason="genuine", thread_path=f"f{i}") for i in range(4)]
+            + [_make_event(EventType.REPLY_CLASSIFIED, verdict="ACCEPT", thread_path="fA")]
+        )
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        types = [c.type for c in clusters]
+        assert TYPE_ESCALATE_OVERRATE in types
+
+    def test_escalate_lm_error_excluded(self, tmp_path):
+        """LLM errors must not count toward escalate rate."""
+        sink = str(tmp_path / "events.jsonl")
+        events = [
+            _make_event(EventType.REPLY_CLASSIFIED, verdict="ESCALATE", reason="LLM error: timeout", thread_path="f1"),
+            _make_event(EventType.REPLY_CLASSIFIED, verdict="ESCALATE", reason="LLM error: timeout", thread_path="f2"),
+            _make_event(EventType.REPLY_CLASSIFIED, verdict="ESCALATE", reason="LLM error: timeout", thread_path="f3"),
+            _make_event(EventType.REPLY_CLASSIFIED, verdict="ACCEPT", thread_path="fA"),
+        ]
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        types = [c.type for c in clusters]
+        assert TYPE_ESCALATE_OVERRATE not in types
+
+    def test_resolution_gap(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = [
+            _make_event(EventType.REPLY_CLASSIFIED, verdict="ACCEPT", thread_path=f"file{i}:10")
+            for i in range(4)
+        ]
+        # No THREAD_RESOLVED events
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        types = [c.type for c in clusters]
+        assert TYPE_RESOLUTION_GAP in types
+
+    def test_resolution_gap_cleared_by_resolved(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        paths = [f"file{i}:10" for i in range(4)]
+        events = (
+            [_make_event(EventType.REPLY_CLASSIFIED, verdict="ACCEPT", thread_path=p) for p in paths]
+            + [_make_event(EventType.THREAD_RESOLVED, thread_path=p) for p in paths]
+        )
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        types = [c.type for c in clusters]
+        assert TYPE_RESOLUTION_GAP not in types
+
+    def test_access_pattern(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = [
+            _make_event(EventType.REQUEST_BLOCKED, actor=f"user{i}") for i in range(6)
+        ]
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        types = [c.type for c in clusters]
+        assert TYPE_ACCESS_PATTERN in types
+
+    def test_signature_is_stable(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = [_make_event(EventType.ERROR, message="err") for _ in range(4)]
+        _write_events(sink, events)
+        c1 = analyze(sink_path=sink)
+        c2 = analyze(sink_path=sink)
+        assert c1[0].signature == c2[0].signature
+
+    def test_clusters_sorted_by_severity(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        # 5 errors → SEVERITY_HIGH (threshold), 6 blocked → SEVERITY_LOW
+        events = (
+            [_make_event(EventType.ERROR, message="err") for _ in range(5)]
+            + [_make_event(EventType.REQUEST_BLOCKED, actor=f"u{i}") for i in range(6)]
+        )
+        _write_events(sink, events)
+        clusters = analyze(sink_path=sink)
+        severities = [c.severity for c in clusters]
+        # High (error_spike) must come before Low (access_pattern)
+        assert severities.index(SEVERITY_HIGH) < severities.index(SEVERITY_LOW)
+
+
+# ── TestFormatter ─────────────────────────────────────────────────────────────
+
+class TestFormatter:
+    def _make_cluster(self, cluster_type=TYPE_ERROR_SPIKE, severity=SEVERITY_HIGH):
+        return ProblemCluster(
+            type=cluster_type,
+            severity=severity,
+            title="Test cluster",
+            evidence=["3 errors observed"],
+            hypothesis="UNVERIFIED: something broke",
+        )
+
+    def test_title_contains_signature(self):
+        cluster = self._make_cluster()
+        title, _, _ = format_issue(cluster, "2026-01-01T00:00:00Z", "2026-01-04T00:00:00Z")
+        assert cluster.signature in title
+
+    def test_body_contains_unverified(self):
+        cluster = self._make_cluster()
+        _, body, _ = format_issue(cluster, "2026-01-01T00:00:00Z", "2026-01-04T00:00:00Z")
+        assert "UNVERIFIED" in body
+
+    def test_body_contains_evidence(self):
+        cluster = self._make_cluster()
+        _, body, _ = format_issue(cluster, "2026-01-01T00:00:00Z", "2026-01-04T00:00:00Z")
+        assert "3 errors observed" in body
+
+    def test_labels_contain_source_self_check(self):
+        cluster = self._make_cluster()
+        _, _, labels = format_issue(cluster, "2026-01-01T00:00:00Z", "2026-01-04T00:00:00Z")
+        assert "source:self-check" in labels
+
+    def test_labels_contain_type(self):
+        cluster = self._make_cluster(cluster_type=TYPE_ERROR_SPIKE)
+        _, _, labels = format_issue(cluster, "2026-01-01T00:00:00Z", "2026-01-04T00:00:00Z")
+        assert "type:bug" in labels
+
+    def test_labels_contain_priority(self):
+        cluster = self._make_cluster(severity=SEVERITY_HIGH)
+        _, _, labels = format_issue(cluster, "2026-01-01T00:00:00Z", "2026-01-04T00:00:00Z")
+        assert any(l.startswith("priority:") for l in labels)
+
+
+# ── TestSelfCheck orchestrator ────────────────────────────────────────────────
+
+class TestSelfCheck:
+    def test_dry_run_files_nothing(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = [_make_event(EventType.ERROR, message="e") for _ in range(4)]
+        _write_events(sink, events)
+        filed = run(days=3, dry_run=True, sink_path=sink)
+        assert filed == 0
+
+    def test_no_problems_no_issues(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        _write_events(sink, [])
+        # Empty sink creates a data_gap cluster; mock dedup as True so it's skipped
+        with patch("argus_self_check._is_duplicate", return_value=True), \
+             patch("argus_self_check._file_issue") as mock_file:
+            filed = run(days=3, dry_run=False, sink_path=sink)
+        mock_file.assert_not_called()
+        assert filed == 0
+
+    def test_max_issues_cap(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        # Generate enough events for multiple clusters
+        events = (
+            [_make_event(EventType.ERROR, message=f"err {i}") for i in range(4)]
+            + [_make_event(EventType.REQUEST_BLOCKED, actor=f"u{i}") for i in range(6)]
+        )
+        _write_events(sink, events)
+        with patch("argus_self_check._is_duplicate", return_value=False), \
+             patch("argus_self_check._file_issue", return_value=42):
+            filed = run(days=3, max_issues=1, dry_run=False, sink_path=sink)
+        assert filed == 1
+
+    def test_dedup_skips_existing(self, tmp_path):
+        sink = str(tmp_path / "events.jsonl")
+        events = [_make_event(EventType.ERROR, message="err") for _ in range(4)]
+        _write_events(sink, events)
+        with patch("argus_self_check._is_duplicate", return_value=True), \
+             patch("argus_self_check._file_issue") as mock_file:
+            filed = run(days=3, dry_run=False, sink_path=sink)
+        mock_file.assert_not_called()
+        assert filed == 0


### PR DESCRIPTION
## Summary

Closes #6

- **Self-check agent** (`argus_self_check.py`, `argus_log_analyzer.py`, `argus_issue_formatter.py`): automated log analysis → GitHub Issue filing with deduplication and severity tiers
- **Adaptive scheduling** (`run_self_check.sh`): interval starts at 3 days, increments to 7 on quiet runs, resets to 3 on findings
- **`USE_DIRECT_PYTHON=1` mode**: bypass Codex CLI and run `python3` directly in container — workaround for openai/codex#13103 WebSocket auth bug; does not require `OPENAI_API_KEY`
- **Tail-scan extractor** (`argus_extractor.py`): for files > 5 MB, seek to tail before scanning — events are append-ordered so recent events are always at end; prevents O(n) full-file reads on large logs
- **Bind-mount logs** (`docker-compose.yml`): change `argus-logs` named volume to `./logs` bind mount so the self-check container can read `events.jsonl` from the host path `/share/homes/392fyc/argus/logs/`
- **Plan C doc fix** (`docs/self-check-setup.md`): correct `ANTHROPIC_BASE_URL` to point to ccproxy (not litellm); clarify purpose is reducing Anthropic subscription load via OpenAI API key
- **`.gitignore`**: exclude `logs/` from VCS

## Deployment (Plan B — NAS)

Container and script deployed to NAS at `/share/homes/392fyc/argus/`. Verified end-to-end with synthetic events:
- Error spike detection ✓
- Dry-run output correct ✓
- Adaptive state file written ✓
- Tail-scan seek path works ✓

**Pending** (requires admin access to QNAP crontab — add via Control Panel → Task Scheduler, daily 02:17):

```
17 2 * * * EVENTS_HOST_PATH=/share/homes/392fyc/argus/logs/events.jsonl ARGUS_STATE_FILE=/share/homes/392fyc/argus/logs/self-check-state.json USE_DIRECT_PYTHON=1 /share/homes/392fyc/argus/scripts/run_self_check.sh >> /share/homes/392fyc/argus/logs/self-check.log 2>&1
```

## Test plan

- [x] Synthetic events dry-run on NAS: error_spike detected, state file updated
- [x] Interval gate: blocks run when `last_run + interval > today`
- [x] `USE_DIRECT_PYTHON=1` bypasses Codex, reads events, produces correct output
- [x] Bind mount: `/share/homes/392fyc/argus/logs:/var/log/argus:rw` verified in container inspect
- [ ] Real events: will populate after first PR review post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
