### PR TITLE
fix: add argus_events.py to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM codiumai/pr-agent:0.34-github_app
 
 COPY entrypoint-guard.py /app/entrypoint-guard.py
 COPY patch_suggestion_format.py /app/patch_suggestion_format.py
+COPY argus_events.py /app/argus_events.py
 
 CMD ["python", "-m", "gunicorn", \
      "-k", "uvicorn.workers.UvicornWorker", \


### PR DESCRIPTION
Hotfix: ModuleNotFoundError on startup — entrypoint-guard.py imports argus_events at module load time but it was missing from the image build.