### PR TITLE
fix(selfcheck): distinguish no-events (INFO) from bad path (WARNING) (#16)

### DIFF
--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -91,8 +91,13 @@ fi
 
 # ── Verify events file ────────────────────────────────────────────────────────
 if [ ! -f "$EVENTS_HOST" ]; then
-  echo "[self-check] WARNING: events file not found at $EVENTS_HOST — skipping run."
-  echo "[self-check] Set EVENTS_HOST_PATH to the correct path and retry."
+  _events_dir="$(dirname "$EVENTS_HOST")"
+  if [ ! -d "$_events_dir" ]; then
+    echo "[self-check] WARNING: events directory not found at $_events_dir — path may be misconfigured."
+    echo "[self-check] Set EVENTS_HOST_PATH to the correct path and retry."
+  else
+    echo "[self-check] INFO: no events file yet at $EVENTS_HOST — nothing to analyze, skipping."
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- `events.jsonl` absent now checks parent directory existence before logging
- Dir missing → `WARNING: path may be misconfigured` + hint to set `EVENTS_HOST_PATH`
- Dir exists, file absent → `INFO: no events file yet — nothing to analyze, skipping`
- Previously always emitted `WARNING` regardless of cause

Eliminates noisy false-positive WARNINGs on first deployment before any events have been collected.

## Also applied (NAS host, no PR needed)

- Created `~/.bash_profile` on NAS (`392fyc@192.168.0.254`) with Container Station docker PATH:
  ```bash
  export PATH="/share/CACHEDEV1_DATA/.qpkg/container-station/bin:$PATH"
  ```
  Fixes `docker: command not found` on interactive SSH login.

## Fixes

Closes #16

## Test plan

- [ ] Fresh deploy (no `/var/log/argus/` dir): expect `WARNING: events directory not found`
- [ ] After deploy, before first events (dir exists, no file): expect `INFO: no events file yet`
- [ ] Normal run (events.jsonl exists): no change in behavior

## dual-verify

Claude: PASS | Codus: PASS (0 Critical, 0 High; pre-existing Medium on grep+pipefail out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)