### PR TITLE
fix(ci): pass CF service token to cloudflared for non-interactive SSH auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +35,7 @@ jobs:
             HostName ssh.fyc-space.uk
             User 392fyc
             IdentityFile ~/.ssh/id_ed25519
-            ProxyCommand cloudflared access ssh --hostname %h
+            ProxyCommand cloudflared access ssh --hostname %h --service-token-id $CF_ACCESS_CLIENT_ID --service-token-secret $CF_ACCESS_CLIENT_SECRET
             StrictHostKeyChecking no
           EOF
 


### PR DESCRIPTION
## Summary
- Deploy workflow was failing at "Setup SSH via Cloudflare Tunnel" with exit code 255
- Root cause: `cloudflared access ssh` triggered browser-based Cloudflare Access auth in CI (non-interactive)
- Fix: add Cloudflare Service Token credentials as job-level env vars and pass `--service-token-id`/`--service-token-secret` flags to `cloudflared access ssh` ProxyCommand

## Changes
- `.github/workflows/deploy.yml`: add `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` job env from secrets
- Update `ProxyCommand` to explicitly pass service token flags

## Prerequisites
- GitHub Secrets `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` must be set (done ✅)

## Test plan
- [ ] Push triggers workflow run
- [ ] "Setup SSH via Cloudflare Tunnel" step passes (no browser prompt)
- [ ] Full deploy completes successfully

Generated with Claude Code