### PR TITLE
fix(ci): remove invalid CF service-token flags from ProxyCommand

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
             HostName ssh.fyc-space.uk
             User 392fyc
             IdentityFile ~/.ssh/id_ed25519
-            ProxyCommand cloudflared access ssh --hostname %h --service-token-id $CF_ACCESS_CLIENT_ID --service-token-secret $CF_ACCESS_CLIENT_SECRET
+            ProxyCommand cloudflared access ssh --hostname %h
             StrictHostKeyChecking no
           EOF
 


### PR DESCRIPTION
## Summary
- Previous fix (PR#18) added `--service-token-id`/`--service-token-secret` flags which are not valid for `cloudflared access ssh`
- cloudflared reads service token credentials from `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET` env vars automatically
- Remove the invalid flags; the job-level env vars from PR#18 already handle this correctly

## Root cause of continued failures
The env vars are correct but the **CF Access Application for `ssh.fyc-space.uk` likely lacks a "Service Auth" policy** allowing the service token.

**Required CF Zero Trust configuration (manual step):**
1. Zero Trust → Access → Applications → `ssh.fyc-space.uk`
2. Policies → Add Policy: Action = "Service Auth", Rule = the created Service Token

## Changes
- `.github/workflows/deploy.yml`: revert ProxyCommand to `cloudflared access ssh --hostname %h` (env vars handle auth)

Generated with Claude Code