### PR TITLE
fix(ci): use TUNNEL_SERVICE_TOKEN_ID/SECRET env vars for cloudflared service token auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-      CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+      # cloudflared access ssh reads TUNNEL_SERVICE_TOKEN_ID/SECRET from env automatically
+      TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET` are NOT read by cloudflared — those are curl/HTTP header conventions
- `cloudflared access ssh` reads `TUNNEL_SERVICE_TOKEN_ID` and `TUNNEL_SERVICE_TOKEN_SECRET` from env automatically
- Remaps existing GitHub Secrets to the correct env var names cloudflared actually parses

## Root cause (confirmed via cloudflared source `cmd/cloudflared/access/cmd.go`)
| Env var cloudflared reads | Equivalent flag |
|---|---|
| `TUNNEL_SERVICE_TOKEN_ID` | `--service-token-id` / `--id` |
| `TUNNEL_SERVICE_TOKEN_SECRET` | `--service-token-secret` / `--secret` |

## Prerequisites
- ✅ GitHub Secrets `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` set
- ✅ CF Zero Trust Access Application has "Service Auth" policy with the service token

Generated with Claude Code