### PR TITLE
fix(ci): inject CF service token directly into ProxyCommand via GH secrets template

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
             HostName ssh.fyc-space.uk
             User 392fyc
             IdentityFile ~/.ssh/id_ed25519
-            ProxyCommand cloudflared access ssh --hostname %h
+            ProxyCommand cloudflared access ssh --hostname %h --service-token-id ${{ secrets.CF_ACCESS_CLIENT_ID }} --service-token-secret ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
             StrictHostKeyChecking no
           EOF
 


### PR DESCRIPTION
## Summary
- Env var approaches (`CF_ACCESS_CLIENT_ID`, `TUNNEL_SERVICE_TOKEN_ID`) do not work for cloudflared when invoked as SSH ProxyCommand subprocess
- Fix: inject GitHub Secrets values directly into the ProxyCommand via `${{ secrets.* }}` template syntax
- GitHub Actions expands `${{ ... }}` before the shell runs, embedding actual credentials into the SSH config
- cloudflared receives `--service-token-id` and `--service-token-secret` flags with real values

## Why this works
`${{ secrets.X }}` is a GitHub Actions template expression expanded at YAML parse time — even inside single-quoted heredoc strings. The SSH config written to disk will contain the literal service token values, bypassing env var inheritance issues in SSH ProxyCommand subprocesses.

## Prerequisites
- ✅ `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` GitHub Secrets set
- ✅ CF Zero Trust Access Application has "Service Auth" policy with the service token

Generated with Claude Code