### PR TITLE
fix(selfcheck): add SKIP_DOCKER_WRAPPER for in-container invocation (#22)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,13 @@ services:
     restart: unless-stopped
     environment:
       - USE_DIRECT_PYTHON=1
+      - DIRECT_PYTHON=1
+      # SKIP_DOCKER_WRAPPER=1 tells run_self_check.sh to invoke
+      # argus_self_check.py directly (in-container) instead of spawning a
+      # sibling docker run. The scheduler container has python3 + the script
+      # baked in and has no docker socket mounted; without this flag the
+      # script exits 127 daily. See #22.
+      - SKIP_DOCKER_WRAPPER=1
       - EVENTS_HOST_PATH=/var/log/argus/events.jsonl
       - ARGUS_STATE_FILE=/var/log/argus/self-check-state.json
     volumes:

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -132,8 +132,17 @@ EXTRA_ARGS=""
 
 # ── Run self-check ────────────────────────────────────────────────────────────
 DOCKER_EXIT=0
-if [ "$DIRECT_PYTHON" = "1" ]; then
-  # Direct Python mode: bypass Codex (workaround for openai/codex#13103 WebSocket auth bug)
+if [ "$SKIP_DOCKER_WRAPPER" = "1" ] && [ "$DIRECT_PYTHON" = "1" ]; then
+  # In-container direct invocation (used by argus-selfcheck-scheduler):
+  # the script already runs inside the argus-selfcheck image, so python3 +
+  # argus_self_check.py are on disk at /workspace. No sibling docker needed.
+  # Fixes issue #22 — scheduler container had no docker binary/socket and
+  # failed exit 127 daily.
+  # shellcheck disable=SC2086
+  GH_TOKEN="${GH_TOKEN:-}" ARGUS_EVENTS_PATH="${EVENTS_CONTAINER}" \
+    python3 argus_self_check.py --days "${DAYS}" --max-issues "${MAX_ISSUES}" ${EXTRA_ARGS} || DOCKER_EXIT=$?
+elif [ "$DIRECT_PYTHON" = "1" ]; then
+  # Direct Python mode on NAS host: bypass Codex (workaround for openai/codex#13103 WebSocket auth bug)
   # shellcheck disable=SC2086
   $DOCKER_CMD run --rm \
     --name "argus-self-check-$$" \


### PR DESCRIPTION
## Summary

Fixes `argus-selfcheck-scheduler` container exiting 127 daily since M3 deploy. Root cause: `run_self_check.sh` unconditionally wraps the Python call in `$DOCKER_CMD run --rm ... ${IMAGE} python3 ...`, but the scheduler container has no docker binary or socket — while the scheduler image itself already bakes in python3 + `argus_self_check.py`, so no sibling container is needed.

Closes #22

## Change

- `scripts/run_self_check.sh`: add new `SKIP_DOCKER_WRAPPER=1` branch that (when combined with `DIRECT_PYTHON=1`) invokes `python3 argus_self_check.py` directly on the in-workspace script file. Existing NAS-host docker-wrapper path preserved for host-side callers.
- `docker-compose.yml`: set `SKIP_DOCKER_WRAPPER=1` + `DIRECT_PYTHON=1` under `selfcheck-scheduler.environment` so deployed instances pick up the fix on next `docker compose up`.

## Evidence

Observed outage window in NAS logs `/share/CACHEDEV1_DATA/homes/392fyc/argus/logs/self-check.log`:

```
[self-check] Starting at 2026-04-13T12:40:15Z
scripts/run_self_check.sh: line 133: docker: command not found
[self-check] Run error (exit 127). Interval unchanged (3 days).
[self-check] Completed at 2026-04-13T12:40:15Z
[self-check] Starting at 2026-04-14T12:40:16Z
scripts/run_self_check.sh: line 133: docker: command not found
[self-check] Run error (exit 127). Interval unchanged (3 days).
[self-check] Starting at 2026-04-15T12:40:16Z
scripts/run_self_check.sh: line 133: docker: command not found
[self-check] Run error (exit 127). Interval unchanged (3 days).
```

Container interior verified:

```
docker exec argus-selfcheck-scheduler sh -c 'which python3 && ls /workspace/argus_self_check.py'
/usr/bin/python3
/workspace/argus_self_check.py
```

## Test plan

- [x] Local lint: `shellcheck scripts/run_self_check.sh` (SC2086 already disabled on the target line)
- [ ] Post-merge: on NAS, `docker compose up -d --force-recreate selfcheck-scheduler`
- [ ] Verify next-day log shows either `[self-check] Quiet run` or `[self-check] Findings detected` instead of `exit 127`

🤖 Generated with [Claude Code](https://claude.com/claude-code)