### PR TITLE
fix(config): max_description_tokens 500->3000 修 ticket-compliance 误报 (Line C, #25)

### DIFF
--- a/configuration.toml
+++ b/configuration.toml
@@ -26,7 +26,14 @@ skip_keys = []
 custom_reasoning_model = true # when true, disables system messages and temperature controls for models that don't support chat-style inputs
 response_language="zh-CN" # Language locales code for PR responses in ISO 3166 and ISO 639 format (e.g., "en-US", "it-IT", "zh-CN", ...)
 # token limits
-max_description_tokens = 500
+# Mercury #476 (Line C): raised 500 -> 3000 so PR bodies that place the
+# Closes/Fixes/Resolves/Refs #N keywords near the END of a long description
+# survive clip_tokens and reach the review prompt's {{description}}. With 500,
+# bodies >~500 tokens were head-clipped and the trailing issue refs were
+# dropped, making the ticket-compliance extra_instructions rule false-positive
+# "missing keyword" (PR #475). 3000 is well within max_model_tokens=32000; the
+# extra input tokens are modest and only apply on /describe,/review,/improve.
+max_description_tokens = 3000
 max_commits_tokens = 500
 max_model_tokens = 32000 # Limits the maximum number of tokens that can be used by any model, regardless of the model's default capabilities.
 custom_model_max_tokens=-1 # for models not in the default list


### PR DESCRIPTION
Closes #25
Refs Mercury #476

## 修复 Line C — ticket-compliance 误报(`max_description_tokens` 截断)

`[config] max_description_tokens` 500 → 3000。

**根因**(Mercury #476 经 9-agent workflow + adversarial 验证):pr-agent `get_pr_description()` 用 `clip_tokens(body, max_description_tokens)` 截 PR body,**保留头、丢弃尾**。500 限制下,Mercury 的 ~1000-token body 被头截,尾部的 `Closes/Fixes/Resolves/Refs #N` 关键字被丢,LLM 评 `.pr_agent.toml` extra_instructions rule 1 时看不到 → 每轮误报「缺少工单关键字」、卡 CHANGES_REQUESTED(PR #475 实证)。`/review` prompt 只嵌 `{{description}}`(无 commit-messages 段、无 ticketing 集成),故被截 description 是该检查唯一文本源。

**修复机理**:#475 body ≈956(o200k)/1119(cl100k)tokens << 3000,`clip_tokens` 早返回不截,整段 body(含尾部 Closes/Refs)进 `{{description}}`。

## 为什么是 config 标量、为什么安全
- `max_description_tokens` 是 `[config]` 标量,与已生效的 `model=gpt-5.3-codex` 同一覆盖机制;无 dynaconf list-merge 歧义。
- 3000 远小于 `max_model_tokens=32000`;额外输入 tokens 很小,仅作用于 `/describe`/`/review`/`/improve`。
- Mercury `.pr_agent.toml` 未设该键,无 repo 级覆盖冲突。

## 验证
- TOML 解析通过;值确为 3000。
- pr-agent **v0.34**(部署镜像 `codiumai/pr-agent:0.34-github_app`)`algo/utils.py clip_tokens` 头留尾丢 + `git_provider.get_pr_description` 调用门控,均 web 核验。
- **dual-verify**:Claude 深审 APPROVE;Codex 审计 APPROVE-WITH-NITS(注释措辞 nit 已改准确)。

## 范围(本 PR 不含)
- **Line A**(`.gitignore` 被上游 `bad_extensions` 过滤,`[Gitignore一致性]` 复报):config-override 路线实施中发现 dynaconf `merge_enabled=True` 的 list-merge 障碍(`configuration.toml` 会被随后加载的 `language_extensions.toml` 覆盖;repo 级 `.pr_agent.toml` 的 list 会被 merge 而非替换),**延后**待线上实测,详见 Mercury #476。
- **Line B**(已答复线程复判 unresolved)、**Line D**(self-check Plan A 架构错配,key+events sink 都在 NAS、GH runner 够不到)独立,见 Mercury #476。

> 注:本 PR 会被 Argus 自己 review,而线上此刻仍是 `max_description_tokens=500`,故关键字 `Closes #25` 已置于 body 顶部以规避正在修的同一 bug(dogfood)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
