### PR TITLE
fix(deploy): ship self-check script+modules to NAS & recreate selfcheck-scheduler (Line D, #29)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,11 +47,22 @@ jobs:
         run: |
           ARGUS_DIR="/share/homes/392fyc/argus"
 
+          # Self-check runtime: the scheduler bind-mounts .:/workspace:ro and runs
+          # these live from $ARGUS_DIR. run_self_check.sh lives under scripts/; the
+          # five argus_*.py modules live at repo root. Ship all so the #22
+          # SKIP_DOCKER_WRAPPER fix and its modules actually reach the NAS. See #29.
           for f in Dockerfile entrypoint-guard.py patch_suggestion_format.py \
-                   configuration.toml docker-compose.yml docker-compose.polling.yml; do
+                   configuration.toml docker-compose.yml docker-compose.polling.yml \
+                   argus_self_check.py argus_log_analyzer.py argus_extractor.py \
+                   argus_events.py argus_issue_formatter.py \
+                   scripts/run_self_check.sh; do
             if [ -f "$f" ]; then
+              ssh nas "mkdir -p $ARGUS_DIR/$(dirname "$f")"
               cat "$f" | ssh nas "cat > $ARGUS_DIR/$f"
               echo "✓ $f"
+            else
+              echo "✗ MISSING in checkout: $f" >&2
+              exit 1
             fi
           done
 
@@ -62,10 +73,23 @@ jobs:
           DHOST="DOCKER_HOST=unix:///var/run/system-docker.sock"
 
           ssh nas "
+            # fail-fast: a failed pr-agent build/up must abort before the scheduler
+            # recreate, otherwise the SSH exit status would reflect only the LAST
+            # command (selfcheck-scheduler) and mask a failed primary rollout.
+            # set -e only (no pipefail) — the NAS remote shell may be busybox, where
+            # 'set -o pipefail' is unsupported and would itself abort under set -e.
+            set -e
             echo '${{ secrets.NAS_SUDO_PASS }}' | sudo -S $DHOST $DOCKER compose \
               -f $ARGUS_DIR/docker-compose.yml build --no-cache pr-agent 2>&1 | tail -5
             echo '${{ secrets.NAS_SUDO_PASS }}' | sudo -S $DHOST $DOCKER compose \
               -f $ARGUS_DIR/docker-compose.yml up -d --force-recreate pr-agent 2>&1
+            # Recreate the self-check scheduler too so the compose-defined
+            # SKIP_DOCKER_WRAPPER=1 env (present since #22) is applied to the running
+            # container. --force-recreate guarantees recreation even if compose sees no
+            # config delta. No rebuild: the image bakes no source; the self-check code
+            # comes from the .:/workspace:ro bind-mount refreshed in the transfer step.
+            echo '${{ secrets.NAS_SUDO_PASS }}' | sudo -S $DHOST $DOCKER compose \
+              -f $ARGUS_DIR/docker-compose.yml up -d --force-recreate selfcheck-scheduler 2>&1
           "
 
       - name: Verify deployment


### PR DESCRIPTION
Closes #29
Refs Mercury #476 (Line D)

## Problem
Argus self-check has NEVER completed on the NAS: `self-check-state.json` `last_run` is always empty; `self-check.log` shows `exit 127 docker: command not found` daily. The #22 SKIP_DOCKER_WRAPPER fix (commit 520c52a) is already on master but never reached the running NAS scheduler because of two `deploy.yml` gaps:

1. **Transfer gap** — the file list shipped only [Dockerfile, entrypoint-guard.py, patch_suggestion_format.py, configuration.toml, docker-compose.yml, docker-compose.polling.yml]. It never shipped `scripts/run_self_check.sh` nor the root-level `argus_*.py` modules. The scheduler bind-mounts `.:/workspace:ro` and runs the script live, so the NAS kept the OLD docker-in-docker script.
2. **Restart gap** — only `pr-agent` was force-recreated; `selfcheck-scheduler` never was, so the compose-defined `SKIP_DOCKER_WRAPPER=1` (present since #22) never reached the ~7-week-old running container.

## Fix (minimal, delicate-area safe)
- **Transfer**: add the 5 self-check modules + `scripts/run_self_check.sh`; `mkdir -p` the dest subdir; fail loud (`exit 1`) on any missing listed file (kills the "forgot a file" bug class).
- **Restart**: add `up -d --force-recreate selfcheck-scheduler`. **No `docker build`** — `Dockerfile.codex` bakes no source; self-check code comes from the bind-mount.
- **Remote ssh block**: add `set -e` so a failed pr-agent build/up aborts before the scheduler recreate (dual-verify Codex finding — otherwise SSH exit would reflect only the last command and mask a failed primary rollout). No `pipefail` (NAS remote shell may be busybox where it is unsupported and would itself abort under `set -e`).
- **Untouched**: cloudflared install / SSH-via-tunnel setup / verify step.

## Web-verified
`docker compose up` recreates a service on config (`environment:`) change; `--force-recreate` forces it regardless — https://docs.docker.com/reference/cli/docker/compose/up/

## Verification (post-deploy, on NAS)
scheduler shows fresh `Up <minutes>`; `docker inspect` shows `SKIP_DOCKER_WRAPPER=1`; `grep -c SKIP_DOCKER_WRAPPER scripts/run_self_check.sh` >=1; `self-check.log` reaches `Completed` exit 0; **`self-check-state.json` `last_run` is now populated** (definition-of-done).

## dual-verify
Claude PASS; Codex NEEDS-CHANGES (1 High: missing fail-fast) -> fixed (`set -e`). YAML parses; transfer-loop dry-run resolves all 12 files (exit 0).

## Out of scope (NEEDS-USER-CONFIRMATION)
Plan A `self-check.yml` GitHub-Actions workflow stays a red-X (no OPENAI_API_KEY secret + runner can't reach NAS-only events.jsonl). Disable via repo var `SELF_CHECK_DISABLED=1` (gated at `self-check.yml:39`) — not done here. Optional follow-up: `run_self_check.sh:135/144` `${SKIP_DOCKER_WRAPPER:-0}` hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)