### PR TITLE
fix(resolve): resolve threads when author posts DISAGREE as a top-level PR comment (Line B, #28)

### DIFF
--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -480,6 +480,115 @@ def _judge_reply_with_llm(original_finding, reply_body):
 MAX_REPLY_ROUNDS = 3
 
 
+_MATCH_STOPWORDS = frozenset({
+    "the", "and", "for", "are", "was", "has", "have", "had", "not", "but",
+    "you", "all", "any", "from", "its", "this", "that", "with", "will",
+    "can", "may", "should", "would", "could", "use", "via", "per", "out",
+    "see", "now", "new", "old", "yet", "off", "let", "get", "than", "then",
+    "their", "they", "them", "what", "when", "which", "while", "your", "here",
+})
+
+
+def _tokenize_for_match(text):
+    """Lowercase -> distinctive alnum/underscore tokens (>=3 chars, stopwords
+    removed) for conservative matching.
+
+    Markdown emphasis underscores (e.g. ``_header_``) are stripped from token
+    edges so ``_verify`` / ``writeback_`` normalise to ``verify`` /
+    ``writeback`` while internal-underscore identifiers (``verify_cache``) are
+    preserved. Common English stopwords are dropped so two findings can't
+    cross-match on filler words like "the"/"and" — the dominant false-resolve
+    risk for Strategy 4.
+
+    Pure function (no I/O) so it is unit-testable without network or LLM.
+    """
+    import re
+    if not text:
+        return set()
+    toks = set()
+    for raw in re.findall(r"[a-z0-9_]+", text.lower()):
+        t = raw.strip("_")
+        if len(t) >= 3 and t not in _MATCH_STOPWORDS:
+            toks.add(t)
+    return toks
+
+
+def _extract_thread_match_keys(first_bot_body, thread_path):
+    """Extract (header_tokens, path_source) used to match a top-level PR
+    comment to THIS thread.
+
+    header_tokens come ONLY from the finding header + content — the
+    ``_{icon} {severity}_ | _{header}_`` and ``**{content}**`` lines that
+    format_review_finding_body() emits BEFORE the ``<details>`` agent-prompt
+    block. We deliberately EXCLUDE that block because it contains the
+    ``In file `{path}` `` reference and the constant "Investigate and fix"
+    boilerplate, which would otherwise leak the file path into header_tokens
+    and collapse the two-signal AND-match into a single (path) signal.
+
+    path_tokens come from the thread's GraphQL ``path`` (authoritative file id),
+    falling back to an ``In file `...` `` reference inside the body. We then
+    SUBTRACT path_tokens from header_tokens so the path signal and the header
+    signal are genuinely INDEPENDENT.
+    """
+    import re
+    # finding signal = everything BEFORE the <details> agent-prompt block
+    finding_signal = (first_bot_body or "").split("<details>", 1)[0]
+
+    path_source = thread_path or ""
+    if not path_source and first_bot_body:
+        m = re.search(r"In file `([^`]+)`", first_bot_body)
+        if m:
+            path_source = m.group(1)
+
+    # tokenize the path on separators so 'scripts/gh-project-flow.md' ->
+    # {scripts, project, flow, ...}; keep the basename whole too.
+    path_tokens = _tokenize_for_match(re.sub(r"[/\\.]", " ", path_source))
+    basename = path_source.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if basename:
+        path_tokens.add(basename.lower())
+
+    # header/content tokens MINUS path tokens -> independent of the path signal
+    header_tokens = _tokenize_for_match(finding_signal) - path_tokens
+    return header_tokens, path_source
+
+
+def _match_toplevel_comment_to_thread(comment_body, header_tokens,
+                                      path_source, min_header_overlap=2):
+    """CONSERVATIVE match: a top-level PR comment matches a thread only when
+    BOTH the comment explicitly names the thread's file AND it shares
+    >= min_header_overlap distinctive finding-header tokens.
+
+    (1) FILE-PATH signal: the comment must contain the full path OR the file
+        basename as a literal substring. Generic path-token overlap (e.g. the
+        bare directory word "scripts") is intentionally NOT accepted — it is too
+        weak and could bind a same-topic comment to the WRONG file and
+        auto-resolve a genuine unaddressed blocker (the dominant risk).
+    (2) HEADER signal: >= min_header_overlap shared finding tokens (path tokens
+        and stopwords already excluded from header_tokens, so the two signals
+        are independent).
+
+    Pure function (no I/O).
+    """
+    if not comment_body:
+        return False
+    comment_tokens = _tokenize_for_match(comment_body)
+    body_lower = comment_body.lower()
+
+    # (1) file-path signal — explicit full-path or basename substring only
+    path_hit = False
+    if path_source and path_source.lower() in body_lower:
+        path_hit = True
+    else:
+        basename = path_source.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
+        if basename and basename in body_lower:
+            path_hit = True
+    if not path_hit:
+        return False
+
+    # (2) header / finding-text signal (independent of the path signal)
+    return len(header_tokens & comment_tokens) >= min_header_overlap
+
+
 def _is_bot_author(login, bot_login):
     """Check if a login matches the bot, handling GraphQL vs REST naming.
 
@@ -577,6 +686,29 @@ def auto_resolve_outdated_threads(provider, pr_number, bot_login="argus-review[b
         resolved_count = 0
         reply_judged = 0
 
+        # Top-level PR (issue) comments — lazily fetched once for the Strategy 4
+        # fallback (author posted a DISAGREE rebuttal as a top-level comment, not
+        # as an in-thread reply). REST: GET /repos/{owner}/{repo}/issues/{pr}/comments
+        # (docs.github.com/en/rest/issues/comments). Bot-authored comments are
+        # filtered out so Argus never matches its own ✅/❓/⚠️ top-level posts.
+        _toplevel_comments_cache = {"loaded": False, "items": []}
+
+        def _get_toplevel_comments():
+            if _toplevel_comments_cache["loaded"]:
+                return _toplevel_comments_cache["items"]
+            _toplevel_comments_cache["loaded"] = True
+            try:
+                rc = _req.get(
+                    f"https://api.github.com/repos/{full_name}/issues/{pr_number}/comments?per_page=100",
+                    headers=auth_h, timeout=15)
+                if rc.status_code == 200:
+                    _toplevel_comments_cache["items"] = [
+                        c for c in rc.json()
+                        if not _is_bot_author(c.get("user", {}).get("login", ""), bot_login)]
+            except Exception as _e:
+                print(f"[Argus] Top-level comment fetch failed (non-fatal): {_e}")
+            return _toplevel_comments_cache["items"]
+
         for t in threads:
             if t["isResolved"]:
                 continue
@@ -616,6 +748,83 @@ def auto_resolve_outdated_threads(provider, pr_number, bot_login="argus-review[b
                     resolved_count += 1
                     print(f"[Argus] Outdated: {thread_path}:{thread_line} → resolved")
                 continue
+
+            # --- Strategy 4: Top-level disagree fallback ------------------
+            # The author posted a DISAGREE/cite rebuttal as a TOP-LEVEL PR
+            # comment (REST issues/{pr}/comments) rather than as an in-thread
+            # reply. Such comments never appear in this thread's `comments`, so
+            # human_authors stays [] and Strategy 3 never fires, leaving the
+            # thread permanently unresolved -> Rule 3 re-emits REQUEST_CHANGES.
+            # GitHub semantics: replying in a thread does NOT flip isResolved —
+            # only resolveReviewThread does. So we scan top-level comments,
+            # CONSERVATIVELY match one to this thread (file-path token AND
+            # finding-header token, both required + independent), and judge it
+            # like a reply via the unchanged _judge_reply_with_llm gate.
+            if not human_authors:
+                # first Argus comment body = the finding text (header + content)
+                first_bot_body = ""
+                first_comment_db_id = None
+                for c in comments["nodes"]:
+                    if _is_bot_author(c.get("author", {}).get("login", ""), bot_login):
+                        first_bot_body = c.get("body", "")
+                        first_comment_db_id = c.get("databaseId")
+                        break
+
+                # Respect MAX_REPLY_ROUNDS: count Argus judgment replies already
+                # posted in this thread by an earlier Strategy 4/3 round.
+                argus_judgment_count = sum(
+                    1 for c in comments["nodes"]
+                    if _is_bot_author(c.get("author", {}).get("login", ""), bot_login)
+                    and any(tag in c.get("body", "") for tag in ("✅ Acknowledged", "❓ Follow-up", "⚠️ Escalated")))
+                if argus_judgment_count >= MAX_REPLY_ROUNDS:
+                    continue
+
+                # Skip if a bot judgment is already the LAST comment: top-level
+                # comments don't re-trigger like in-thread replies, so the matched
+                # comment is unchanged and re-judging would just duplicate the bot
+                # reply (REJECT/ESCALATE don't resolve, so human_authors stays []
+                # and this block would otherwise re-run + re-post every cycle).
+                JUDGMENT_TAGS = ("✅ Acknowledged", "❓ Follow-up", "⚠️ Escalated")
+                last_comment = comments["nodes"][-1]
+                if _is_bot_author(last_comment.get("author", {}).get("login", ""), bot_login) \
+                        and any(tag in last_comment.get("body", "") for tag in JUDGMENT_TAGS):
+                    continue
+
+                if first_bot_body and first_comment_db_id:
+                    header_tokens, path_source = _extract_thread_match_keys(
+                        first_bot_body, thread_path)
+                    matched_body = None
+                    for tc in _get_toplevel_comments():
+                        if _match_toplevel_comment_to_thread(
+                                tc.get("body", ""), header_tokens, path_source):
+                            matched_body = tc.get("body", "")
+                            break
+                    if matched_body:
+                        verdict, reason = _judge_reply_with_llm(
+                            first_bot_body, matched_body)
+                        reply_judged += 1
+                        if verdict == "ESCALATE" and "LLM error" in reason:
+                            print(f"[Argus] Top-level reply judgment LLM failed for {thread_path}: {reason}")
+                            continue
+                        if verdict == "ACCEPT":
+                            _reply_to_thread(auth_h, full_name, pr_number,
+                                             first_comment_db_id,
+                                             f"✅ Acknowledged — {reason}")
+                            if _resolve_thread(auth_h, thread_id):
+                                resolved_count += 1
+                                print(f"[Argus] Top-level reply accepted: {thread_path} → resolved")
+                        elif verdict == "REJECT":
+                            _reply_to_thread(auth_h, full_name, pr_number,
+                                             first_comment_db_id,
+                                             f"❓ Follow-up — {reason}")
+                            print(f"[Argus] Top-level reply rejected: {thread_path} → follow-up posted")
+                        else:  # ESCALATE (genuine, not LLM error)
+                            _reply_to_thread(auth_h, full_name, pr_number,
+                                             first_comment_db_id,
+                                             f"⚠️ Escalated — {reason}\n\n"
+                                             f"*This thread requires human reviewer input.*")
+                            print(f"[Argus] Top-level reply escalated: {thread_path}")
+                        continue
 
             # --- Strategy 3: Reply-aware judging (thread has human replies) ---
             if human_authors:

--- a/tests/test_toplevel_match.py
+++ b/tests/test_toplevel_match.py
@@ -1,0 +1,155 @@
+"""Unit tests for the Strategy 4 top-level-comment matching helpers in
+patch_suggestion_format.py (Line B / Mercury #476).
+
+These exercise the three PURE helpers that decide whether a top-level PR
+comment rebuts a given review thread:
+
+    _tokenize_for_match
+    _extract_thread_match_keys
+    _match_toplevel_comment_to_thread
+
+They take no network / LLM, so no pr_agent stubbing is needed (the heavy
+imports in patch_suggestion_format are lazy/inside functions). Finding bodies
+are generated with the real format_review_finding_body() so the tests stay
+faithful to the production thread layout.
+
+The dominant risk for Strategy 4 is auto-resolving a GENUINE unaddressed
+blocker via a loose match, so the matcher requires BOTH an independent
+file-path signal AND a finding-header signal. The disambiguation + independence
+tests below guard exactly that.
+"""
+
+import sys
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import patch_suggestion_format as psf  # noqa: E402
+
+
+FILE_A = "scripts/gh-project-flow.md"
+
+# Finding A — cache/writeback theme
+FINDING_A = psf.format_review_finding_body({
+    "issue_header": "Verify cache before writeback",
+    "issue_content": ("The propagate step reads stale ranking data and "
+                      "overwrites fresh writes without a guard."),
+    "relevant_file": FILE_A,
+    "start_line": 40,
+    "end_line": 44,
+})
+
+# Finding B — SAME file, deliberately DISJOINT vocabulary from A
+FINDING_B = psf.format_review_finding_body({
+    "issue_header": "Hardcoded mount location",
+    "issue_content": ("Replace the absolute NAS directory with an environment "
+                      "variable lookup."),
+    "relevant_file": FILE_A,
+    "start_line": 88,
+    "end_line": 88,
+})
+
+# A top-level PR comment rebutting Finding A (quotes the file + A's vocabulary)
+COMMENT_REBUTS_A = (
+    "DISAGREE — on `scripts/gh-project-flow.md` the cache writeback is "
+    "actually guarded: `verify_cache()` runs before propagate, so this is a "
+    "false positive."
+)
+
+
+def test_tokenize_basics():
+    toks = psf._tokenize_for_match("Verify the CACHE_before  writeback!!")
+    assert "verify" in toks
+    assert "cache_before" in toks  # underscore kept as one token
+    assert "writeback" in toks
+    assert "the" not in toks       # <3 chars dropped
+    assert psf._tokenize_for_match("") == set()
+    assert psf._tokenize_for_match(None) == set()
+
+
+def test_header_tokens_exclude_path_and_boilerplate():
+    """Core correctness guard: header_tokens must be INDEPENDENT of the path
+    signal and must NOT leak the <details> agent-prompt boilerplate."""
+    header_tokens, path_source = psf._extract_thread_match_keys(
+        FINDING_A, FILE_A)
+    assert path_source == FILE_A
+    # path tokens are SUBTRACTED out of header_tokens (independence)
+    assert "scripts" not in header_tokens
+    assert "flow" not in header_tokens
+    assert "project" not in header_tokens
+    # agent-prompt boilerplate lives in the <details> block -> excluded
+    for boiler in ("investigate", "described", "above", "action", "required"):
+        assert boiler not in header_tokens, boiler
+    # genuine finding vocabulary survives
+    for kw in ("cache", "writeback", "propagate", "guard"):
+        assert kw in header_tokens, kw
+
+
+def test_positive_match():
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    assert psf._match_toplevel_comment_to_thread(COMMENT_REBUTS_A, *keys) is True
+
+
+def test_file_path_miss():
+    """Same finding vocabulary but the comment names a DIFFERENT file with no
+    shared path token -> path signal absent -> no match."""
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    comment = ("The cache writeback before propagate is guarded in "
+               "`src/unrelated/other_module.py`.")
+    assert psf._match_toplevel_comment_to_thread(comment, *keys) is False
+
+
+def test_generic_path_word_is_not_a_path_signal():
+    """A comment that uses a generic directory word ('scripts') from the path
+    but does NOT name the file (no full path, no basename) must NOT satisfy the
+    file-path signal — even with strong header overlap. Guards the dominant
+    false-resolve risk surfaced by the Codex audit (Line B)."""
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    comment = ("Lots of scripts in this PR; the cache writeback before "
+               "propagate logic is fine and already guarded.")
+    assert psf._match_toplevel_comment_to_thread(comment, *keys) is False
+
+
+def test_header_miss():
+    """Right file, but a generic comment with <2 finding-token overlap -> no
+    match (header signal below threshold)."""
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    comment = "Thanks for the review of `scripts/gh-project-flow.md`, looks good to me."
+    assert psf._match_toplevel_comment_to_thread(comment, *keys) is False
+
+
+def test_same_file_disambiguation():
+    """Two findings on the SAME file with disjoint vocab: a comment rebutting A
+    must match A's thread and NOT B's thread. Guards against same-file
+    cross-matching (the dominant false-resolve risk)."""
+    keys_a = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    keys_b = psf._extract_thread_match_keys(FINDING_B, FILE_A)
+    assert psf._match_toplevel_comment_to_thread(COMMENT_REBUTS_A, *keys_a) is True
+    assert psf._match_toplevel_comment_to_thread(COMMENT_REBUTS_A, *keys_b) is False
+
+
+def test_basename_only_path_reference():
+    """A comment that names just the basename (no dir prefix) still satisfies
+    the file-path signal via the basename branch."""
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    comment = ("On gh-project-flow.md the cache writeback before propagate is "
+               "already guarded.")
+    assert psf._match_toplevel_comment_to_thread(comment, *keys) is True
+
+
+def test_path_fallback_from_body():
+    """thread_path empty -> path_source is recovered from the `In file \\`...\\``
+    reference inside the finding body."""
+    header_tokens, path_source = psf._extract_thread_match_keys(
+        FINDING_A, "")
+    assert path_source == FILE_A
+    assert psf._match_toplevel_comment_to_thread(
+        COMMENT_REBUTS_A, header_tokens, path_source) is True
+
+
+def test_empty_comment_is_no_match():
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    assert psf._match_toplevel_comment_to_thread("", *keys) is False
+    assert psf._match_toplevel_comment_to_thread(None, *keys) is False


### PR DESCRIPTION
Closes #28
Refs Mercury #476 (Line B)

## Problem
When the PR author posts a DISAGREE/cite rebuttal as a **top-level PR comment** (REST `issues/{pr}/comments`) instead of an in-thread reply, Argus never resolves the thread. `auto_resolve_outdated_threads` computes `human_authors` only from IN-THREAD comments, so `human_authors == []`, the reply-aware Strategy 3 (gated `if human_authors:`) never fires, `_judge_reply_with_llm`/`_resolve_thread` are never called, and Rule 3 re-emits REQUEST_CHANGES every iteration ("Actionable: 0" yet "🔴 N unresolved"). GitHub semantics: replying in a thread does NOT flip `isResolved` — only `resolveReviewThread` does.

## Fix — Strategy 4
Inserted between Strategy 2 (isOutdated) and Strategy 3, gated `if not human_authors:` (mutually exclusive with Strategy 3). Lazily fetches top-level PR comments (one `GET issues/{pr}/comments` per run, max), CONSERVATIVELY matches one to the thread, feeds it to the **unchanged** `_judge_reply_with_llm`, and on ACCEPT posts the ack reply + `resolveReviewThread`. Unmatched threads fall through to status-quo (stay unresolved) — the safe direction.

### Conservative two-signal AND match (dominant risk = auto-resolving a real blocker)
- **File-path signal**: comment must contain the full path OR basename as a literal substring. Generic path-token overlap (bare `scripts`) is NOT accepted (dual-verify Codex finding).
- **Header signal**: ≥2 shared finding tokens, derived only from the finding header+content (before the `<details>` block), with path tokens AND stopwords subtracted → the two signals are independent (markdown emphasis underscores stripped from token edges).
- **Already-judged guard**: if a bot judgment is the last in-thread comment, skip re-judging (top-level comments don't re-trigger; REJECT/ESCALATE would otherwise duplicate replies each run — dual-verify Codex finding). ACCEPT self-terminates via `isResolved`; `MAX_REPLY_ROUNDS` still capped.

## Scope guards
- Does NOT modify the `_judge_reply_with_llm` ESCALATE prompt (this is **not** the #8 fix; `test_reply_classifier.py` anchors stay green).
- Companion **#23** (mention-rewriter) must be sequenced so it doesn't strip the author's rebuttal body before Strategy 4 scans it. NOT implemented here.

## Tests
New `tests/test_toplevel_match.py` (10 cases: positive, file-path miss, generic-word-not-a-signal, header miss, same-file disambiguation, basename-only, body-path fallback, independence, empty). **All 39 repo tests pass.**

## Web-verified
- resolveReviewThread + reply!=resolve — https://docs.github.com/en/graphql/reference/mutations
- list issue (top-level PR) comments — https://docs.github.com/en/rest/issues/comments
- review-vs-issue comment distinction — https://docs.github.com/en/rest/pulls/comments

## dual-verify
Claude PASS; Codex NEEDS-CHANGES (1 High path-signal + 1 Medium re-judge) -> fixed -> re-audit PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)