### PR TITLE
fix(review): re-include config dotfiles (.gitignore) in Files-reviewed footer (Line A, #27)

### DIFF
--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -215,11 +215,31 @@ def build_aggregated_agent_prompt(issues: list) -> str:
     return "\n".join(lines)
 
 
+# Config dotfiles that pr-agent's is_valid_file() drops (their final
+# split('.')[-1] token is in bad_extensions.default, e.g. 'gitignore'), so
+# they never reach diff_files and are omitted from the footer. We re-include
+# them in the '📒 Files reviewed' footer ONLY (display) — their content was
+# never sent to the model, so this restores footer VISIBILITY but does not
+# itself feed .gitignore to the reviewer. The actual [Gitignore一致性] false
+# positive is neutralized by the top-level disagree auto-resolve (Line B / #28).
+# Verified: pr-agent v0.34 language_handler.is_valid_file returns
+# filename.split('.')[-1] not in bad_extensions; 'gitignore' is in
+# bad_extensions.default. Refs Argus #27 / Mercury #476 (Line A).
+_FOOTER_REINCLUDE_DOTFILES = frozenset({
+    ".gitignore", ".gitattributes", ".dockerignore", ".editorconfig",
+})
+
+
 def build_review_body_additions(findings: list, inline_count: int,
-                                diff_files=None) -> str:
+                                diff_files=None, extra_filenames=None) -> str:
     """Build CodeRabbit-style additions to prepend/append to review body.
 
     Adds: actionable comments count, aggregated AI prompt, review info.
+
+    extra_filenames: optional iterable of filenames that pr-agent filtered out
+    of diff_files (e.g. .gitignore) but were genuinely changed in the PR;
+    merged into the 'Files reviewed' footer for display only. Default None
+    keeps the footer byte-for-byte identical for every existing caller.
     """
     parts = []
 
@@ -245,6 +265,18 @@ def build_review_body_additions(findings: list, inline_count: int,
     if diff_files:
         try:
             file_list = [getattr(f, 'filename', str(f)) for f in diff_files[:30]]
+        except Exception:
+            pass
+    # Re-include config dotfiles pr-agent's is_valid_file() dropped (footer
+    # display only — these were never sent to the model for review). Dedup +
+    # keep the same 30-file cap; appends only, never evicts a reviewed file.
+    if extra_filenames:
+        try:
+            seen = set(file_list)
+            for fn in extra_filenames:
+                if fn and fn not in seen and len(file_list) < 30:
+                    file_list.append(fn)
+                    seen.add(fn)
         except Exception:
             pass
 
@@ -1337,9 +1369,44 @@ def apply_patch():
                 no_new_code=no_new_code,
                 escalated_threads=escalated_threads)
 
+            # Collect config dotfiles pr-agent filtered out of diff_files
+            # (e.g. .gitignore — its split('.')[-1] token is in
+            # bad_extensions.default) so the footer can re-include them. Fully
+            # guarded: on any failure footer_extra stays [] and the footer is
+            # unchanged. Display only — never feeds content to the model.
+            footer_extra = []
+            try:
+                token_ff = _get_github_token(self.git_provider)
+                if token_ff and pr_number:
+                    repo_ff = self.git_provider.repo
+                    fn_ff = repo_ff.full_name if hasattr(repo_ff, 'full_name') else str(repo_ff)
+                    diff_names = set()
+                    if diff_files:
+                        for _df in diff_files:
+                            _n = getattr(_df, 'filename', None)
+                            if _n:
+                                diff_names.add(_n)
+                    import requests as _req_ff
+                    auth_ff = {"Authorization": f"Bearer {token_ff}",
+                               "Accept": "application/vnd.github+json"}
+                    r_ff = _req_ff.get(
+                        f"https://api.github.com/repos/{fn_ff}/pulls/{pr_number}/files",
+                        headers=auth_ff, params={"per_page": 100}, timeout=15)
+                    if r_ff.status_code == 200:
+                        for _f in r_ff.json():
+                            _name = _f.get("filename", "")
+                            _base = _name.rsplit("/", 1)[-1]
+                            if (_base in _FOOTER_REINCLUDE_DOTFILES
+                                    and _name not in diff_names):
+                                footer_extra.append(_name)
+            except Exception as e:
+                footer_extra = []  # strict: any failure -> footer byte-for-byte unchanged
+                print(f"[Argus] Footer dotfile re-include failed (non-fatal): {e}")
+
             # Build enhanced review body (CodeRabbit-style)
             body_additions = build_review_body_additions(
-                findings, len(inline_comments), diff_files)
+                findings, len(inline_comments), diff_files,
+                extra_filenames=footer_extra)
 
             # Strip PR Reviewer Guide from incremental reviews (iteration >= 2)
             # The full guide is only useful on the first review; subsequent reviews

--- a/tests/test_footer_reinclude.py
+++ b/tests/test_footer_reinclude.py
@@ -1,0 +1,74 @@
+"""Unit tests for the config-dotfile footer re-include in
+build_review_body_additions (Line A / Mercury #476).
+
+pr-agent's is_valid_file() drops config dotfiles like .gitignore (their
+split('.')[-1] token is in bad_extensions.default), so they never reach
+diff_files and are omitted from the '📒 Files reviewed' footer. The new
+extra_filenames param re-includes an allowlist of such dotfiles in the footer
+for DISPLAY ONLY (content is never sent to the model).
+
+build_review_body_additions is a pure formatter (no network), so these run
+without pr_agent / GitHub access.
+"""
+
+import sys
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import patch_suggestion_format as psf  # noqa: E402
+
+
+class _FakeFile:
+    def __init__(self, filename):
+        self.filename = filename
+
+
+def test_none_reproduces_prepatch_footer_byte_for_byte():
+    """Regression guard: extra_filenames=None (the default) must produce a
+    footer identical to omitting the argument — i.e. byte-for-byte unchanged
+    behavior for every existing caller."""
+    diff = [_FakeFile("a.py"), _FakeFile("b.py")]
+    body_omitted = psf.build_review_body_additions([], 0, diff)
+    body_none = psf.build_review_body_additions([], 0, diff, extra_filenames=None)
+    assert body_omitted == body_none
+    # the reviewed files appear; no dotfile leaked in
+    assert "* `a.py`" in body_none
+    assert "Files reviewed (2)" in body_none
+    assert ".gitignore" not in body_none
+
+
+def test_extra_filename_is_added_to_footer():
+    diff = [_FakeFile("a.py")]
+    body = psf.build_review_body_additions([], 0, diff, extra_filenames=[".gitignore"])
+    assert "* `a.py`" in body
+    assert "* `.gitignore`" in body
+    assert "Files reviewed (2)" in body
+
+
+def test_extra_filename_dedup():
+    """A dotfile already present in diff_files must not be duplicated."""
+    diff = [_FakeFile(".gitignore"), _FakeFile("a.py")]
+    body = psf.build_review_body_additions([], 0, diff, extra_filenames=[".gitignore"])
+    assert body.count("* `.gitignore`") == 1
+    assert "Files reviewed (2)" in body
+
+
+def test_thirty_file_cap_is_respected():
+    """The footer caps at 30 files; extras are not appended past the cap so a
+    genuinely reviewed file is never evicted."""
+    diff = [_FakeFile(f"f{i}.py") for i in range(30)]
+    body = psf.build_review_body_additions([], 0, diff, extra_filenames=[".gitignore"])
+    assert "Files reviewed (30)" in body
+    assert "* `.gitignore`" not in body  # cap full -> extra not added
+
+
+def test_empty_and_malformed_extra_is_noop():
+    diff = [_FakeFile("a.py")]
+    base = psf.build_review_body_additions([], 0, diff)
+    assert psf.build_review_body_additions([], 0, diff, extra_filenames=[]) == base
+    # falsy entries are skipped without error
+    body = psf.build_review_body_additions([], 0, diff, extra_filenames=["", None])
+    assert body == base


### PR DESCRIPTION
Closes #27
Refs Mercury #476 (Line A)

## Problem
pr-agent v0.34 `is_valid_file()` returns `filename.split('.')[-1] not in bad_extensions`. `'.gitignore'.split('.')[-1] == 'gitignore'` ∈ `bad_extensions.default`, so `GithubProvider.get_diff_files()` filters `.gitignore` out (cached in `self.diff_files`) before Argus reads it. The "📒 Files reviewed" footer is built from that filtered set, so `.gitignore` is omitted even when changed → the model tends to claim it unreviewed (`[Gitignore一致性]` FP).

## ⚠️ Scope: this is FOOTER DISPLAY ONLY
`.gitignore` content is never sent to the model (findings come from `key_issues_to_review` over `diff_files`). Re-including it in the footer restores **visibility** but cannot by itself guarantee the FP disappears — the actual FP-neutralization path is the top-level disagree auto-resolve (**Line B / #28**). This edit complements it by removing the "missing from footer" signal.

## Why not the config route (web-verified, rejected)
- pr-agent loads `configuration.toml` BEFORE `language_extensions.toml`; `custom_merge_loader` REPLACES lists → an Argus `configuration.toml [bad_extensions]` override loses.
- Mercury repo-level `.pr_agent.toml` loads last via stock dynaconf 3.2.4 (`merge_enabled=True`) which APPENDS lists; dynaconf docs confirm merge markers work only for first-level keys, not nested lists → a `[bad_extensions]` replace marker is unreliable.

## Fix (Argus-owned code patch — no upstream-image change, no dynaconf trap)
- `_FOOTER_REINCLUDE_DOTFILES` allowlist + opt-in `extra_filenames=None` param on `build_review_body_additions` (default None = **byte-for-byte unchanged** for all callers; single in-repo call site).
- Call site fetches the PR's actual changed files (`GET /pulls/{n}/files`, same `_get_github_token`+requests pattern used elsewhere), passes allowlisted dotfiles absent from `diff_files`. Fully try/except-guarded → `footer_extra=[]` on **any** failure (strict no-op).
- Footer union dedups + keeps the 30-file cap (append-only, never evicts a reviewed file).

## Tests
`tests/test_footer_reinclude.py` — None==omitted byte-for-byte regression guard, add, dedup, 30-cap, empty/malformed no-op. **All 34 repo tests pass.**

## Web-verified
- `is_valid_file` / `bad_extensions.default` / `get_diff_files` caching — pr-agent v0.34 source (language_handler.py, language_extensions.toml, github_provider.py)
- dynaconf list-merge markers — https://www.dynaconf.com/merging/

## dual-verify
Claude PASS; Codex NEEDS-CHANGES (1 Low: except didn't reset partial `footer_extra`) → fixed (strict reset).

## Follow-up (out of scope)
Whether to feed `.gitignore` CONTENT to the model (actual review, not just footer) is a larger change bypassing `is_valid_file` in the diff pipeline — deferred; the LLM FP is better neutralized by Line B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)