### PR TITLE
fix: #476 follow-up hardening — deploy fail-fast + set-u guard + Line B match precision (#35)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,9 +78,17 @@ jobs:
             # command (selfcheck-scheduler) and mask a failed primary rollout.
             # set -e only (no pipefail) — the NAS remote shell may be busybox, where
             # 'set -o pipefail' is unsupported and would itself abort under set -e.
+            # The build therefore writes to a log file (no pipe) so its non-zero exit
+            # reaches set -e directly; a trailing '| tail' would otherwise mask a
+            # failed build behind tail's success exit (#476 Line D hardening).
             set -e
-            echo '${{ secrets.NAS_SUDO_PASS }}' | sudo -S $DHOST $DOCKER compose \
-              -f $ARGUS_DIR/docker-compose.yml build --no-cache pr-agent 2>&1 | tail -5
+            if ! echo '${{ secrets.NAS_SUDO_PASS }}' | sudo -S $DHOST $DOCKER compose \
+                 -f $ARGUS_DIR/docker-compose.yml build --no-cache pr-agent > /tmp/argus-build.log 2>&1; then
+              echo 'pr-agent build FAILED — last 20 lines:' >&2
+              tail -20 /tmp/argus-build.log >&2
+              exit 1
+            fi
+            tail -5 /tmp/argus-build.log
             echo '${{ secrets.NAS_SUDO_PASS }}' | sudo -S $DHOST $DOCKER compose \
               -f $ARGUS_DIR/docker-compose.yml up -d --force-recreate pr-agent 2>&1
             # Recreate the self-check scheduler too so the compose-defined

--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -584,6 +584,24 @@ def _extract_thread_match_keys(first_bot_body, thread_path):
     return header_tokens, path_source
 
 
+def _filename_mentioned(needle, haystack_lower):
+    """True if ``needle`` (a lowercased path or basename) appears in
+    ``haystack_lower`` as a BOUNDED filename token — not as the prefix of a
+    longer name.
+
+    Guards the Strategy-4 path signal against ``foo.py`` matching ``foo.py.bak``
+    or ``myfoo.py``: the chars immediately before/after the match must NOT be
+    filename-continuation chars (``[A-Za-z0-9._-]``). A path separator (``/`` or
+    ``\\``) is not such a char, so ``dir/foo.py`` still matches the basename
+    ``foo.py``. Pure function (no I/O). #476 Line B hardening.
+    """
+    import re
+    if not needle:
+        return False
+    pat = r"(?<![A-Za-z0-9._-])" + re.escape(needle) + r"(?![A-Za-z0-9._-])"
+    return re.search(pat, haystack_lower) is not None
+
+
 def _match_toplevel_comment_to_thread(comment_body, header_tokens,
                                       path_source, min_header_overlap=2):
     """CONSERVATIVE match: a top-level PR comment matches a thread only when
@@ -606,13 +624,16 @@ def _match_toplevel_comment_to_thread(comment_body, header_tokens,
     comment_tokens = _tokenize_for_match(comment_body)
     body_lower = comment_body.lower()
 
-    # (1) file-path signal — explicit full-path or basename substring only
+    # (1) file-path signal — explicit full-path OR basename as a BOUNDED filename
+    # token (#476 Line B hardening: 'foo.py' must not match 'foo.py.bak' or
+    # 'myfoo.py'). Generic path-token overlap (the bare directory word "scripts")
+    # is still intentionally NOT accepted — too weak.
     path_hit = False
-    if path_source and path_source.lower() in body_lower:
+    if path_source and _filename_mentioned(path_source.lower(), body_lower):
         path_hit = True
     else:
         basename = path_source.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
-        if basename and basename in body_lower:
+        if _filename_mentioned(basename, body_lower):
             path_hit = True
     if not path_hit:
         return False
@@ -826,7 +847,9 @@ def auto_resolve_outdated_threads(provider, pr_number, bot_login="argus-review[b
                     header_tokens, path_source = _extract_thread_match_keys(
                         first_bot_body, thread_path)
                     matched_body = None
-                    for tc in _get_toplevel_comments():
+                    # newest-first: REST issues/comments returns oldest-first, so a
+                    # later rebuttal should win over a stale earlier one (#476 Line B).
+                    for tc in reversed(_get_toplevel_comments()):
                         if _match_toplevel_comment_to_thread(
                                 tc.get("body", ""), header_tokens, path_source):
                             matched_body = tc.get("body", "")

--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -632,7 +632,9 @@ def _match_toplevel_comment_to_thread(comment_body, header_tokens,
     if path_source and _filename_mentioned(path_source.lower(), body_lower):
         path_hit = True
     else:
-        basename = path_source.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
+        # (path_source or "") guards the rsplit against a None path_source —
+        # the only caller passes "" not None, but keep the helper self-safe.
+        basename = (path_source or "").rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
         if _filename_mentioned(basename, body_lower):
             path_hit = True
     if not path_hit:

--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -848,8 +848,9 @@ def auto_resolve_outdated_threads(provider, pr_number, bot_login="argus-review[b
                         first_bot_body, thread_path)
                     matched_body = None
                     # newest-first: REST issues/comments returns oldest-first, so a
-                    # later rebuttal should win over a stale earlier one (#476 Line B).
-                    for tc in reversed(_get_toplevel_comments()):
+                    # later rebuttal should win over a stale earlier one. list() guards
+                    # reversed() against any non-sequence return (#476 Line B).
+                    for tc in reversed(list(_get_toplevel_comments())):
                         if _match_toplevel_comment_to_thread(
                                 tc.get("body", ""), header_tokens, path_source):
                             matched_body = tc.get("body", "")

--- a/scripts/run_self_check.sh
+++ b/scripts/run_self_check.sh
@@ -43,6 +43,10 @@ DAYS="${SELF_CHECK_DAYS:-3}"
 MAX_ISSUES="${SELF_CHECK_MAX_ISSUES:-5}"
 DRY_RUN="${SELF_CHECK_DRY_RUN:-0}"
 DIRECT_PYTHON="${USE_DIRECT_PYTHON:-0}"
+# Default so the bare "$SKIP_DOCKER_WRAPPER" test below is safe under `set -u`.
+# The compose scheduler sets SKIP_DOCKER_WRAPPER=1, but a host-cron invocation
+# that does not export it would otherwise abort with "unbound variable" (#476).
+SKIP_DOCKER_WRAPPER="${SKIP_DOCKER_WRAPPER:-0}"
 EVENTS_HOST="${EVENTS_HOST_PATH:-/var/log/argus/events.jsonl}"
 EVENTS_CONTAINER="${ARGUS_EVENTS_PATH:-/var/log/argus/events.jsonl}"
 IMAGE="${CODEX_IMAGE:-argus-selfcheck}"

--- a/tests/test_toplevel_match.py
+++ b/tests/test_toplevel_match.py
@@ -186,3 +186,11 @@ def test_prefixed_filename_does_not_false_match():
     comment = ("The cache writeback before propagate logic in "
                "`xgh-project-flow.md` is guarded.")
     assert psf._match_toplevel_comment_to_thread(comment, *keys) is False
+
+
+def test_none_path_source_does_not_crash():
+    """path_source=None must NOT raise (None.rsplit) — the basename branch
+    guards with (path_source or '') and returns no match (#476 Line B)."""
+    header_tokens, _ = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    assert psf._match_toplevel_comment_to_thread(
+        COMMENT_REBUTS_A, header_tokens, None) is False

--- a/tests/test_toplevel_match.py
+++ b/tests/test_toplevel_match.py
@@ -153,3 +153,36 @@ def test_empty_comment_is_no_match():
     keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
     assert psf._match_toplevel_comment_to_thread("", *keys) is False
     assert psf._match_toplevel_comment_to_thread(None, *keys) is False
+
+
+def test_filename_mentioned_boundaries():
+    """_filename_mentioned matches a filename only as a BOUNDED token, so a name
+    is never matched as the prefix/suffix of a longer name (#476 Line B)."""
+    fm = psf._filename_mentioned
+    assert fm("foo.py", "the bug is in foo.py here") is True
+    assert fm("foo.py", "see `foo.py` for details") is True       # backtick boundary
+    assert fm("foo.py", "patched in dir/foo.py already") is True   # path-sep boundary
+    assert fm("foo.py", "foo.py.bak is the stale copy") is False   # trailing '.' extension
+    assert fm("foo.py", "myfoo.py is a different file") is False   # leading alnum
+    assert fm("foo.py", "the compiled foo.pyc is fine") is False   # trailing alnum
+    assert fm("", "anything") is False
+    assert fm("foo.py", "no mention of it") is False
+
+
+def test_sibling_backup_filename_does_not_false_match():
+    """A comment that names a CONFUSINGLY-similar sibling (the thread's file plus
+    a '.bak' suffix) must NOT satisfy the path signal, even with full header
+    overlap — the basename/full-path must match as a bounded token (#476 Line B)."""
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    comment = ("DISAGREE — in the backup `scripts/gh-project-flow.md.bak` the "
+               "cache writeback before propagate is already guarded.")
+    assert psf._match_toplevel_comment_to_thread(comment, *keys) is False
+
+
+def test_prefixed_filename_does_not_false_match():
+    """A filename whose basename is only a SUFFIX of a longer name must not match
+    (the char before the basename is alphanumeric) (#476 Line B)."""
+    keys = psf._extract_thread_match_keys(FINDING_A, FILE_A)
+    comment = ("The cache writeback before propagate logic in "
+               "`xgh-project-flow.md` is guarded.")
+    assert psf._match_toplevel_comment_to_thread(comment, *keys) is False


### PR DESCRIPTION
## Issue
Closes #35
<!-- Optional hardening surfaced by Argus self-review at #476 wrap-up; user-approved to implement now. -->

## Summary
1. **deploy.yml (Line D)** — `compose build ... 2>&1 | tail -5` let a failed build hide behind `tail`'s success exit under `set -e` (busybox has no `pipefail`). Build now writes to `/tmp/argus-build.log` (no pipe); `if !` catches non-zero build exit → tail to stderr → `exit 1` aborts before rollout. Removing the `| tail` pipe is the fix; `set -e` only suspends inside the `if` condition, staying active for the later `up -d` steps.
2. **run_self_check.sh** — default `SKIP_DOCKER_WRAPPER="${SKIP_DOCKER_WRAPPER:-0}"` so the bare `"$SKIP_DOCKER_WRAPPER"` test is safe under `set -euo pipefail` on a host-cron invocation that doesn't export it (compose scheduler always sets it).
3. **patch_suggestion_format.py (Line B / #31)** — new `_filename_mentioned()` matches a path/basename only as a BOUNDED filename token, so `foo.py` no longer false-matches `foo.py.bak`/`myfoo.py` (path separator still counts as a boundary). Strategy-4 top-level scan iterates newest-first (`reversed`) so a later rebuttal wins over a stale earlier one (REST returns oldest-first).
4. **tests** — +3 tests for the bounded-match behavior.

## Verification
- Local: 18 tests pass; `python ast.parse` + `bash -n` + YAML `safe_load` all OK.
- **Dual-verify: PASS** (Claude deep-review: PASS 0 issues; Codex audit: PASS 0 findings).
- Dual-verify Codex side: PASS

Refs Mercury #476, Argus #28 #29