### PR TITLE
fix(mention-rewriter): route trailing @argus-review review to /review (#23)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           # these live from $ARGUS_DIR. run_self_check.sh lives under scripts/; the
           # five argus_*.py modules live at repo root. Ship all so the #22
           # SKIP_DOCKER_WRAPPER fix and its modules actually reach the NAS. See #29.
-          for f in Dockerfile entrypoint-guard.py patch_suggestion_format.py \
+          for f in Dockerfile entrypoint-guard.py mention_rewrite.py patch_suggestion_format.py \
                    configuration.toml docker-compose.yml docker-compose.polling.yml \
                    argus_self_check.py argus_log_analyzer.py argus_extractor.py \
                    argus_events.py argus_issue_formatter.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM codiumai/pr-agent:0.34-github_app
 
 COPY entrypoint-guard.py /app/entrypoint-guard.py
+COPY mention_rewrite.py /app/mention_rewrite.py
 COPY patch_suggestion_format.py /app/patch_suggestion_format.py
 COPY argus_events.py /app/argus_events.py
 

--- a/entrypoint-guard.py
+++ b/entrypoint-guard.py
@@ -3,7 +3,7 @@ Argus Guard — User whitelist + @mention support for PR-Agent GitHub App webhoo
 
 Features:
 - User whitelist: only allowed users' events pass through
-- @mention rewrite: converts @argus-review[bot] mentions to /ask commands
+- @mention rewrite: converts @argus-review[bot] mentions to PR-Agent slash commands
 
     ARGUS_ALLOWED_USERS=392fyc,trusted-bot   (comma-separated, case-insensitive)
 
@@ -12,9 +12,9 @@ If empty or unset, ALL users are allowed.
 
 import json
 import os
-import re
 
 from argus_events import emitter, EventType
+from mention_rewrite import should_rewrite_mention, rewrite_mention
 
 _raw = os.environ.get("ARGUS_ALLOWED_USERS", "").strip()
 ALLOWED_USERS: set = set()
@@ -93,60 +93,11 @@ class ArgusGuardMiddleware:
         return await self.app(scope, replay_receive, send)
 
 
-# ── @mention → /ask rewrite ──────────────────────────────────────
-# Rewrites @argus-review[bot] mentions as /ask commands so PR-Agent
-# can process them. Must be applied AFTER HMAC verification (at the
-# handler level, not the ASGI middleware level).
-#
-# Pattern: matches @argus-review[bot] or @argus-review (with or without [bot])
-# Ref: https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment
-
-BOT_MENTION_RE = re.compile(
-    r'@argus-review(?:\[bot\])?\s*', re.IGNORECASE)
-
-# Patterns that indicate the mention is in a quote (not a direct request)
-QUOTE_PREFIX_RE = re.compile(r'^\s*>')
-
-
-def _should_rewrite_mention(body: str) -> bool:
-    """Check if comment body contains a direct @mention (not in a quote)."""
-    if not BOT_MENTION_RE.search(body):
-        return False
-    # Don't rewrite if the mention is only in quoted lines
-    for line in body.split('\n'):
-        if BOT_MENTION_RE.search(line) and not QUOTE_PREFIX_RE.match(line):
-            return True
-    return False
-
-
-PR_AGENT_COMMANDS = {
-    "review", "describe", "improve", "ask", "help",
-    "update_changelog", "similar_issue", "add_docs", "test",
-}
-
-
-def _rewrite_mention(body: str) -> str:
-    """Rewrite @argus-review mentions to PR-Agent slash commands.
-
-    Supports both styles:
-      @argus-review review        → /review
-      @argus-review review -i     → /review -i
-      @argus-review /review       → /review
-      @argus-review why is X bad? → /ask why is X bad?
-    """
-    cleaned = BOT_MENTION_RE.sub("", body).strip()
-    if not cleaned:
-        return ""
-    # Already a slash command — pass through
-    if cleaned.startswith("/"):
-        return cleaned
-    # Check if first word is a known PR-Agent command
-    first_word = cleaned.split()[0].lower()
-    if first_word in PR_AGENT_COMMANDS:
-        rest = cleaned[len(first_word):].strip()
-        return f"/{first_word} {rest}".rstrip()
-    # Fallback: treat as /ask
-    return f"/ask {cleaned}"
+# @mention → slash-command rewriting lives in mention_rewrite.py
+# (pure + unit-tested in tests/test_mention_rewrite.py). The intent classifier
+# keys off the verb following a mention, with the LAST explicit-command mention
+# winning so a trailing "@argus-review review" re-triggers review even when a
+# fix-summary body precedes it (Argus #23).
 
 
 def _handle_reply_to_argus(body, sender):
@@ -348,23 +299,23 @@ def _patch_mention_handler():
                     _handle_reply_to_argus(body, sender)
 
                 # Rewrite @mentions to PR-Agent commands
-                if _should_rewrite_mention(comment_body):
-                    rewritten = _rewrite_mention(comment_body)
+                if should_rewrite_mention(comment_body):
+                    rewritten, method = rewrite_mention(comment_body)
                     if rewritten:
-                        print(f"[Argus] @mention rewritten: "
+                        print(f"[Argus] @mention rewritten ({method}): "
                               f"'{comment_body[:60]}' → '{rewritten[:60]}'")
                         body["comment"]["body"] = rewritten
                         _pr_num = body.get("pull_request", {}).get("number")
                         _repo = body.get("repository", {}).get("full_name")
                         emitter.emit(EventType.MENTION_REWRITTEN, pr_number=_pr_num,
                                      repo=_repo, original=comment_body[:60],
-                                     rewritten=rewritten[:60])
+                                     rewritten=rewritten[:60], method=method)
 
             return await original_handle(body, event, sender, sender_id,
                                          action, log_context, agent)
 
         ga_mod.handle_comments_on_pr = patched_handle
-        print("[Argus] @mention → /ask rewrite patched")
+        print("[Argus] @mention rewrite patched")
     except Exception as e:
         print(f"[Argus] Failed to patch @mention handler: {e}")
 

--- a/mention_rewrite.py
+++ b/mention_rewrite.py
@@ -1,0 +1,96 @@
+"""
+Argus — @mention → PR-Agent slash-command rewriting (pure, unit-testable).
+
+Extracted from entrypoint-guard.py so the intent-classification logic can be
+unit-tested without importing pr_agent (Argus #23).
+
+Intent is detected from the verb that FOLLOWS an @argus-review mention, and the
+LAST explicit-command mention wins — the trailing-trigger convention: users
+write a fix summary as context, then "@argus-review review" on the final line
+to re-trigger an incremental review. Body text preceding the trailing trigger
+is context, NOT a question. This fixes the bug where a findings-list body was
+misclassified as a question and routed to /ask, so the intended /review never
+fired and the PR stalled in a nit-loop (Argus #23 / Mercury PR #253).
+"""
+
+import re
+
+# Matches @argus-review or @argus-review[bot], plus any trailing whitespace.
+BOT_MENTION_RE = re.compile(r'@argus-review(?:\[bot\])?\s*', re.IGNORECASE)
+
+# A line beginning with '>' is a Markdown quote — a mention there is not a trigger.
+QUOTE_PREFIX_RE = re.compile(r'^\s*>')
+
+PR_AGENT_COMMANDS = {
+    "review", "describe", "improve", "ask", "help",
+    "update_changelog", "similar_issue", "add_docs", "test",
+}
+
+
+def should_rewrite_mention(body: str) -> bool:
+    """True if body contains a direct (non-quoted) @argus-review mention."""
+    if not body or not BOT_MENTION_RE.search(body):
+        return False
+    # Don't rewrite if the mention appears only inside quoted lines.
+    for line in body.split('\n'):
+        if BOT_MENTION_RE.search(line) and not QUOTE_PREFIX_RE.match(line):
+            return True
+    return False
+
+
+def _line_containing(body: str, pos: int) -> str:
+    """Return the full text of the line that contains character index `pos`."""
+    start = body.rfind('\n', 0, pos) + 1
+    end = body.find('\n', pos)
+    if end == -1:
+        end = len(body)
+    return body[start:end]
+
+
+def rewrite_mention(body: str):
+    """Rewrite @argus-review mentions to a PR-Agent slash command.
+
+    Returns ``(command, method)`` where ``method`` records the decision so the
+    rewrite is debuggable from events.jsonl (Argus #23 item 3):
+
+      - ``explicit-trailing-verb``: a known command verb (review/ask/...) directly
+        followed a non-quoted mention; the LAST such mention wins (trailing
+        trigger). Preceding body is treated as context, not a question.
+      - ``slash-passthrough``: the body (minus mentions) already starts with a
+        slash command.
+      - ``freeform-ask-fallback``: no explicit command verb → treat the whole
+        body as a question for /ask.
+      - ``empty``: nothing remained after stripping mentions.
+
+    Examples::
+
+        "@argus-review review"                 -> ("/review", explicit-trailing-verb)
+        "@argus-review review -i"              -> ("/review -i", explicit-trailing-verb)
+        "<fix summary>\\n@argus-review review"  -> ("/review", explicit-trailing-verb)
+        "@argus-review why is X bad?"          -> ("/ask why is X bad?", freeform-ask-fallback)
+    """
+    if not body:
+        return ("", "empty")
+    explicit = None  # (verb, args) from the LAST non-quoted command mention
+    for m in BOT_MENTION_RE.finditer(body):
+        if QUOTE_PREFIX_RE.match(_line_containing(body, m.start())):
+            continue  # mention inside a quote is context, not a trigger
+        rest_of_line = body[m.end():].split('\n', 1)[0].strip()
+        if not rest_of_line:
+            continue
+        first = rest_of_line.split()[0]
+        verb = first.lstrip('/').lower()
+        if verb in PR_AGENT_COMMANDS:
+            args = rest_of_line[len(first):].strip()
+            explicit = (verb, args)
+
+    if explicit:
+        verb, args = explicit
+        return (f"/{verb} {args}".rstrip(), "explicit-trailing-verb")
+
+    cleaned = BOT_MENTION_RE.sub("", body).strip()
+    if not cleaned:
+        return ("", "empty")
+    if cleaned.startswith("/"):
+        return (cleaned, "slash-passthrough")
+    return (f"/ask {cleaned}", "freeform-ask-fallback")

--- a/mention_rewrite.py
+++ b/mention_rewrite.py
@@ -28,8 +28,13 @@ PR_AGENT_COMMANDS = {
 
 
 def should_rewrite_mention(body: str) -> bool:
-    """True if body contains a direct (non-quoted) @argus-review mention."""
-    if not body or not BOT_MENTION_RE.search(body):
+    """True if body contains a direct (non-quoted) @argus-review mention.
+
+    Non-string input (a malformed webhook payload where ``comment.body`` is not
+    a string) is treated as "no mention" rather than raised, so a single bad
+    comment cannot break the whole webhook handler.
+    """
+    if not isinstance(body, str) or not BOT_MENTION_RE.search(body):
         return False
     # Don't rewrite if the mention appears only inside quoted lines.
     for line in body.split('\n'):
@@ -69,7 +74,7 @@ def rewrite_mention(body: str):
         "<fix summary>\\n@argus-review review"  -> ("/review", explicit-trailing-verb)
         "@argus-review why is X bad?"          -> ("/ask why is X bad?", freeform-ask-fallback)
     """
-    if not body:
+    if not isinstance(body, str) or not body:
         return ("", "empty")
     explicit = None  # (verb, args) from the LAST non-quoted command mention
     for m in BOT_MENTION_RE.finditer(body):

--- a/tests/test_mention_rewrite.py
+++ b/tests/test_mention_rewrite.py
@@ -1,0 +1,148 @@
+"""Unit tests for mention_rewrite.py — the @argus-review → slash-command
+intent classifier (Argus #23).
+
+The bug these guard: a re-review trigger written as a fix-summary body followed
+by a trailing ``@argus-review review`` line was misclassified as a question and
+routed to ``/ask`` (because the OLD classifier looked at the first word of the
+whole stripped body), so the intended incremental ``/review`` never fired and
+the PR stalled in a nit-loop (Mercury PR #253). The classifier now keys off the
+verb that FOLLOWS a mention, with the LAST explicit-command mention winning.
+
+Pure functions — no pr_agent / network, so no stubbing needed.
+"""
+
+import sys
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from mention_rewrite import should_rewrite_mention, rewrite_mention  # noqa: E402
+
+
+# ── should_rewrite_mention ────────────────────────────────────────
+
+def test_should_rewrite_direct_mention():
+    assert should_rewrite_mention("@argus-review review") is True
+
+
+def test_should_rewrite_bot_suffix():
+    assert should_rewrite_mention("@argus-review[bot] review") is True
+
+
+def test_should_not_rewrite_no_mention():
+    assert should_rewrite_mention("just a normal comment") is False
+
+
+def test_should_not_rewrite_empty():
+    assert should_rewrite_mention("") is False
+    assert should_rewrite_mention(None) is False
+
+
+def test_should_not_rewrite_quote_only():
+    body = "> @argus-review review\n\nI disagree with this finding."
+    assert should_rewrite_mention(body) is False
+
+
+def test_should_rewrite_mixed_quote_and_direct():
+    body = "> @argus-review said earlier\n\n@argus-review review"
+    assert should_rewrite_mention(body) is True
+
+
+# ── rewrite_mention: existing conventions still hold ──────────────
+
+def test_explicit_review():
+    assert rewrite_mention("@argus-review review") == ("/review", "explicit-trailing-verb")
+
+
+def test_explicit_review_incremental_flag():
+    assert rewrite_mention("@argus-review review -i") == ("/review -i", "explicit-trailing-verb")
+
+
+def test_explicit_slash_form():
+    assert rewrite_mention("@argus-review /review") == ("/review", "explicit-trailing-verb")
+
+
+def test_explicit_ask_verb():
+    cmd, method = rewrite_mention("@argus-review ask why is the cache stale?")
+    assert cmd == "/ask why is the cache stale?"
+    assert method == "explicit-trailing-verb"
+
+
+def test_freeform_question_falls_back_to_ask():
+    assert rewrite_mention("@argus-review why is X bad?") == (
+        "/ask why is X bad?", "freeform-ask-fallback")
+
+
+# ── rewrite_mention: the #23 regression cases ─────────────────────
+
+def test_trailing_review_after_fix_summary():
+    """A fix summary as context + a trailing review trigger must route to /review,
+    not /ask. This is the exact failure mode from Mercury PR #253."""
+    body = (
+        "iter-4 3 findings 处理 (commit 0677596):\n\n"
+        "1. **🔵 语义冲突** — fixed by renaming the var\n"
+        "2. **🟡 perf** — added a guard\n\n"
+        "@argus-review review"
+    )
+    assert rewrite_mention(body) == ("/review", "explicit-trailing-verb")
+
+
+def test_leading_and_trailing_mentions_last_wins():
+    """Two mentions: a leading context mention (non-command verb) and a trailing
+    explicit review trigger. The trailing explicit command wins."""
+    body = (
+        "@argus-review iter-4 3 findings 处理 (commit 0677596):\n\n"
+        "1. **🔵 语义冲突** — resolved\n\n"
+        "@argus-review review"
+    )
+    assert rewrite_mention(body) == ("/review", "explicit-trailing-verb")
+
+
+def test_trailing_review_incremental_after_body():
+    body = "Fixed all the nits.\n\n@argus-review review -i"
+    assert rewrite_mention(body) == ("/review -i", "explicit-trailing-verb")
+
+
+def test_quoted_trailing_trigger_is_ignored():
+    """A review verb inside a quote is not a real trigger; the genuine freeform
+    mention drives the result."""
+    body = "@argus-review what changed?\n\n> @argus-review review"
+    cmd, method = rewrite_mention(body)
+    assert cmd.startswith("/ask")
+    assert method == "freeform-ask-fallback"
+
+
+def test_last_explicit_command_wins_over_earlier():
+    body = "@argus-review describe\n\n@argus-review review"
+    assert rewrite_mention(body) == ("/review", "explicit-trailing-verb")
+
+
+# ── rewrite_mention: edge cases ───────────────────────────────────
+
+def test_empty_after_strip():
+    assert rewrite_mention("@argus-review") == ("", "empty")
+
+
+def test_none_and_empty_body_safe():
+    # rewrite_mention is independently safe even though the call site gates on
+    # should_rewrite_mention (which already rejects None/empty).
+    assert rewrite_mention(None) == ("", "empty")
+    assert rewrite_mention("") == ("", "empty")
+
+
+def test_unknown_slash_passthrough():
+    cmd, method = rewrite_mention("@argus-review /custom_thing foo")
+    assert cmd == "/custom_thing foo"
+    assert method == "slash-passthrough"
+
+
+def test_case_insensitive_mention():
+    assert rewrite_mention("@Argus-Review review") == ("/review", "explicit-trailing-verb")
+
+
+def test_freeform_multiword_question_preserved():
+    cmd, method = rewrite_mention("@argus-review is this thread safe under concurrency?")
+    assert cmd == "/ask is this thread safe under concurrency?"
+    assert method == "freeform-ask-fallback"

--- a/tests/test_mention_rewrite.py
+++ b/tests/test_mention_rewrite.py
@@ -132,6 +132,31 @@ def test_none_and_empty_body_safe():
     assert rewrite_mention("") == ("", "empty")
 
 
+def test_non_string_body_safe():
+    # A malformed webhook where comment.body is not a string must degrade to a
+    # no-op rather than raising TypeError out of the handler (Argus #37 review).
+    for bad in ({"x": 1}, ["review"], 42, 3.14):
+        assert should_rewrite_mention(bad) is False
+        assert rewrite_mention(bad) == ("", "empty")
+
+
+def test_verb_on_next_line_kept_as_review():
+    # The mention regex's trailing whitespace spans the newline, so a verb on the
+    # line directly below the mention is still recognized — preserving the prior
+    # behavior (the old classifier also routed this to /review). Locked in so a
+    # future regex tightening is a conscious decision, not an accident.
+    assert rewrite_mention("@argus-review\nreview") == ("/review", "explicit-trailing-verb")
+
+
+def test_quoted_verb_on_next_line_is_not_a_trigger():
+    # Conversely, a quoted verb on the next line must NOT be promoted to /review.
+    # This is the harmless case behind the Minor "line-divergence" review note:
+    # the captured token is the quote marker, which is not a known command.
+    cmd, method = rewrite_mention("@argus-review\n> review")
+    assert method == "freeform-ask-fallback"
+    assert not cmd.startswith("/review")
+
+
 def test_unknown_slash_passthrough():
     cmd, method = rewrite_mention("@argus-review /custom_thing foo")
     assert cmd == "/custom_thing foo"


### PR DESCRIPTION
## What

Fixes the @mention rewriter (Argus #23): PR re-review triggers were misrouted to `/ask` instead of `/review`.

**Bug**: the convention is to write a fix-summary body, then a trailing `@argus-review review` line to re-trigger an incremental review. The old `_rewrite_mention` looked at the **first word of the whole stripped body** (e.g. `iter-4`), misclassified it as a question, and emitted `/ask <body>` — so the review never fired and PRs stalled in nit-loops (observed on Mercury PR #253; contributed to admin-merge escape-hatches).

## How

- **Intent now keys off the verb FOLLOWING each mention**, and the **LAST non-quoted explicit-command mention wins** (trailing-trigger convention). `/ask <whole body>` is the fallback only when no mention is followed by a known command verb. Quoted (`> @argus-review …`) mentions are ignored as triggers.
- The rewrite decision is recorded as a `method` field on the `MENTION_REWRITTEN` event (`explicit-trailing-verb` / `slash-passthrough` / `freeform-ask-fallback` / `empty`) for debuggability — **#23 item 3**.
- **Extracted** the pure helpers from `entrypoint-guard.py` into a new module `mention_rewrite.py` so they unit-test without importing `pr_agent` (whose heavy imports run at `entrypoint-guard` module load). `import re` removed from `entrypoint-guard.py`; call site updated to the `(command, method)` tuple API.
- `mention_rewrite.py` added to the **Dockerfile COPY** list and the **deploy.yml NAS transfer** list (reaches both the container image and the scheduler bind-mount).

## Tests

- New `tests/test_mention_rewrite.py` — 21 cases incl. the exact PR #253 repro (CJK findings body + trailing `@argus-review review` + real commit SHA), all conventions, quoted mentions, last-wins, slash forms, freeform `/ask`, None/empty safety.
- **Full suite: 90 passed** (`python -m pytest tests/ -q`). `py_compile` clean.

## Verification

Dual-verify (parallel, on the staged diff) — **both lanes APPROVE-WITH-NITS, 0 Critical/High/Medium**:
- **Codex code-audit**: classifier correct, extraction clean, reply-handling order preserved (thread-resolution unaffected), Dockerfile + deploy.yml shipping correct.
- **Claude deep-review (Opus)**: spec compliance PASS; no regression to any prior convention; Line B / Strategy 4 interaction confirmed safe (`_handle_reply_to_argus` runs before the in-memory body mutation; the thread-resolution scan reads from the GitHub API, not the payload).

Nit disposition:
- ✅ Applied: `rewrite_mention(None)` guard (independent safety + test); two stale `/ask` operator strings in `entrypoint-guard.py` corrected; `_line_containing` docstring "byte offset" → "character index".
- 🟡 DISAGREE (kept): tighten `BOT_MENTION_RE` `\s*` → `[^\S\n]*` — declined because it would regress `@argus-review\nreview` (verb on next line; old code routed it to `/review`), and both reviewers confirmed the current `\s*` line-divergence is **harmless** under the command set (a verb pulled from a quoted next line yields a `>`-prefixed token that is not a command → freeform fallback). Backward-compat preferred over removing a theoretical-only footgun.
- 📋 Follow-up (out of scope): add `__pycache__/`, `*.pyc`, `.pr-flow-*` to `.gitignore` (untracked artifacts were correctly NOT staged here).

## Line B interaction

Per the #476 carry-note ("#23 must not strip the author rebuttal body before the Strategy 4 scan"): the rewrite mutates **only** the in-memory `body["comment"]["body"]` passed to pr-agent's command router. The Strategy 4 top-level-comment thread-resolution scan reads the **original** comments from the GitHub API, and `_handle_reply_to_argus` (reply-judging) runs on the original body **before** the rewrite. No regression to thread resolution / reply-judging.

Closes #23
