### PR TITLE
chore(#498): rebase base image codiumai:0.34→pragent/pr-agent:0.38.0 (escape frozen base) + config drift repair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ docker-compose.override.yml
 
 # Argus event log (bind-mounted from Docker container, not for VCS)
 logs/
+
+# pr-flow skill working files (PR-monitoring scratch state)
+.pr-flow-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM codiumai/pr-agent:0.34-github_app
+# Base image: PR-Agent (community-maintained successor of Qodo's codiumai/pr-agent).
+# Rebased off the FROZEN codiumai/pr-agent:0.34 (last publish ~2026-05; and per
+# qodo-ai/pr-agent#2306 that tag actually shipped 0.32-era code) onto the active
+# pragent/pr-agent namespace. Digest-pinned, not a floating tag, per the #2306
+# build-pipeline-trust lesson.
+#   tag:    pragent/pr-agent:0.38.0-github_app   (PyPI pr-agent 0.38.0, 2026-06-26)
+#   source: PyPI author "Qodo AI"; GitHub the-pr-agent/pr-agent (community-owned)
+#   digest below is the multi-arch (amd64+arm64) manifest, timestamp-matches PyPI.
+# Mercury #498.
+FROM pragent/pr-agent:0.38.0-github_app@sha256:f07a88d52c816aef04fee53e31fa99b5ff9fd9dee186e652677f730a2b0888bc
 
 COPY entrypoint-guard.py /app/entrypoint-guard.py
 COPY mention_rewrite.py /app/mention_rewrite.py

--- a/configuration.toml
+++ b/configuration.toml
@@ -3,11 +3,11 @@
 
 [config]
 # models
-model="gpt-5.3-codex"
-model_turbo="gpt-5.3-codex"
-fallback_models=["gpt-5.4-mini"]
+model="azure/responses/gpt-5.3-codex"
+model_turbo="azure/responses/gpt-5.3-codex"
+fallback_models=["azure/gpt-5.4"]
 #model_reasoning="o4-mini" # dedicated reasoning model for self-reflection
-#model_weak="gpt-4o" # optional, a weaker model to use for some easier tasks
+model_weak="azure/gpt-5.4-mini" # fast/light flows (user-allocated 2026-07-03); main review stays gpt-5.3-codex
 # CLI
 git_provider="github"
 publish_output=true
@@ -36,7 +36,7 @@ response_language="zh-CN" # Language locales code for PR responses in ISO 3166 a
 max_description_tokens = 3000
 max_commits_tokens = 500
 max_model_tokens = 32000 # Limits the maximum number of tokens that can be used by any model, regardless of the model's default capabilities.
-custom_model_max_tokens=-1 # for models not in the default list
+custom_model_max_tokens=272000 # for models not in the default list
 model_token_count_estimate_factor=0.3 # factor to increase the token count estimate, in order to reduce likelihood of model failure due to too many tokens - applicable only when requesting an accurate estimate.
 # patch extension logic
 patch_extension_skip_types =[".md",".txt"]

--- a/entrypoint-guard.py
+++ b/entrypoint-guard.py
@@ -277,7 +277,7 @@ def _patch_mention_handler():
     1. Judge replies to Argus review threads via LLM
     2. Rewrite @mentions before the slash-command filter drops them
 
-    handle_comments_on_pr signature (PR-Agent 0.34):
+    handle_comments_on_pr signature (PR-Agent 0.34-0.38, unchanged):
       async def handle_comments_on_pr(body, event, sender, sender_id,
                                        action, log_context, agent)
     """

--- a/patch_suggestion_format.py
+++ b/patch_suggestion_format.py
@@ -1151,10 +1151,15 @@ def apply_patch():
 
         original_push = pr_code_suggestions.PRCodeSuggestions.push_inline_code_suggestions
 
-        def patched_push(self, data):
+        # async: upstream push_inline_code_suggestions is `async def` (v0.34+); the
+        # caller does `await self.push_inline_code_suggestions(...)`, so the replacement
+        # must be awaitable. (The old codiumai:0.34 image shipped 0.32 code where this
+        # method was sync — hence the fork was sync and happened to work; the 0.38 rebase
+        # requires async. git_provider.publish_code_suggestions stays sync upstream.)
+        async def patched_push(self, data):
             code_suggestions = []
             if not data.get("code_suggestions"):
-                return original_push(self, data)
+                return await original_push(self, data)
 
             for d in data["code_suggestions"]:
                 try:
@@ -1200,7 +1205,7 @@ def apply_patch():
         from pr_agent.tools import pr_reviewer
         from pr_agent.algo.utils import load_yaml
         from pr_agent.git_providers import github_provider as gh_mod
-        from pr_agent.git_providers.github_provider import find_line_number_of_relevant_line_in_file
+        from pr_agent.algo.utils import find_line_number_of_relevant_line_in_file
 
         # -- Step A: Intercept publish to capture review body --
         original_publish_persistent = gh_mod.GithubProvider.publish_persistent_comment
@@ -1209,13 +1214,22 @@ def apply_patch():
         def _is_review_content(body):
             return isinstance(body, str) and ("PR Reviewer Guide" in body or "Reviewer Guide" in body)
 
-        def patched_publish_persistent(self, body, initial_header="", **kwargs):
+        def patched_publish_persistent(self, pr_comment, initial_header, update_header=True,
+                                       name="review", final_update_message=True):
+            # v0.36+ added name/final_update_message params (0.34 had neither). Mirror the
+            # upstream signature exactly (incl. required initial_header) so positional call
+            # sites bind instead of falling into a **kwargs that cannot absorb extra
+            # positional args. The known v0.38 caller (PRReviewer.run) passes keywords; this
+            # hardens against positional callers and fails fast on a bad one.
+            body = pr_comment
             if _is_review_content(body):
                 # Capture body, don't publish yet — patched_run will post unified review
                 self._argus_review_body = body
                 print(f"[Argus] Captured review body ({len(body)} chars), deferring publish")
                 return
-            return original_publish_persistent(self, body, initial_header=initial_header, **kwargs)
+            return original_publish_persistent(self, pr_comment, initial_header=initial_header,
+                                               update_header=update_header, name=name,
+                                               final_update_message=final_update_message)
 
         def patched_publish_comment(self, body, is_temporary=False):
             if not is_temporary and _is_review_content(body):


### PR DESCRIPTION
## What & why

Rebases Argus's Docker base image off the **frozen** `codiumai/pr-agent:0.34-github_app` onto the actively-maintained `pragent/pr-agent:0.38.0-github_app` (digest-pinned). Tracks **Mercury #498** (P3 maintenance; decoupled from the #476 false-positive work — the rebase gives zero FP reduction, it is purely supply-chain / staleness hygiene).

The old namespace stopped publishing at 0.34 (~2026-05) and, per [qodo-ai/pr-agent#2306](https://github.com/qodo-ai/pr-agent/issues/2306), the `0.34` tag actually shipped **0.32-era code** (the running container reports `pr-agent 0.3.1` / `litellm 1.81.12`). Frozen base = no future security/bug patches.

> #498 evaluated **0.36.1**; since then upstream shipped **0.37.0** and **0.38.0** (2026-06-26). Both changelogs touch **none** of the 14 fork coupling points, and 0.38.0 still pins `PyGithub==1.59.*` (so the #14 name-mangled-token chain holds). Landing on the latest (0.38.0) rather than an already-2-versions-stale 0.36.1 — that IS the point of escaping the frozen base.

## Supply-chain due diligence

- Namespace `pragent/pr-agent` is the legit successor: PyPI author "Qodo AI", GitHub `the-pr-agent/pr-agent` (community-owned), Docker Hub tag timestamps match PyPI publish dates.
- **Digest-pinned, not a floating tag** (the #2306 lesson is a build-pipeline-trust failure):
  `pragent/pr-agent:0.38.0-github_app@sha256:f07a88d52c816aef04fee53e31fa99b5ff9fd9dee186e652677f730a2b0888bc`
  — multi-arch (amd64+arm64) manifest, so platform-agnostic on the NAS.

## Changes (2 commits)

**1. `fix(config)` — configuration.toml drift repair (prerequisite)**
The 2026-07-03 AOAI switch was applied directly on the NAS and never flowed back to this repo. `deploy.yml` ships `configuration.toml` on every master push, so merging *any* PR would clobber the working NAS routing with stale bare model names and break every review. Backfilled the 5 drifted lines to match the authoritative NAS copy (verified content-identical):
- `model` / `model_turbo`: `gpt-5.3-codex` → `azure/responses/gpt-5.3-codex`
- `fallback_models`: `["gpt-5.4-mini"]` → `["azure/gpt-5.4"]` (fallback intentionally uses the plain-chat path, not Responses)
- `model_weak`: enabled `azure/gpt-5.4-mini`
- `custom_model_max_tokens`: `-1` → `272000`

The routing itself lives in `.secrets.toml [openai]` (`api_type=azure` + `api_base` + `api_version=2025-03-01-preview` + `deployment_id`), which `deploy.yml` does NOT transfer → preserved on the NAS.

**2. `feat(#498)` — base rebase + 4 fork coupling adaptations** (verified vs v0.38.0 raw source)
- **#1** `patched_push` → `async def` + `await original_push`: upstream `push_inline_code_suggestions` is `async def` (since v0.34) and the caller awaits it. The 0.32 code the old image shipped had a *sync* method, so the sync fork worked by accident. Inner `publish_code_suggestions` stays sync (not awaited).
- **#5** `patched_publish_persistent`: mirror upstream's explicit signature `(pr_comment, initial_header, update_header, name, final_update_message)` instead of `(body, initial_header, **kwargs)` so positional call sites bind.
- **#8** `find_line_number_of_relevant_line_in_file`: import from canonical `pr_agent.algo.utils` (call unchanged — 4-arg, 2-tuple).
- **#11** `chat_completion`: **no change** — fork's 2-tuple unpack already matches upstream v0.38 async `(resp, finish_reason)`.

Coupling points #2/#3/#4/#6/#7/#9/#10/#12/#13/#14 confirmed unchanged vs v0.38.0.

## Verification

- 93/93 Argus unit tests pass; `py_compile` clean.
- **Dual-verify** (cross-repo manual, since `/dual-verify` assumes single-repo): both **0 blocking**.
  - *Codex code-audit*: APPROVE; 1 Minor → made `patched_publish_persistent`'s `initial_header` required (mirror upstream, fail-fast). **Applied.**
  - *Claude deep-review*: **APPROVE**; independently re-verified the full un-adapted coupling surface (handle_comments_on_pr 7-param, PRReviewer/PRDescription.run, dedent_code, publish_code_suggestions dict keys, load_yaml, review-header string, finding schema, all PyGithub usage) all survive v0.38.0 unchanged. Nits applied (stale `0.34` comment, `.pr-flow-*` gitignore).
- litellm bump 1.81.12 → 1.84.0 (same 1.8x line); `azure/responses/` is a stable litellm feature, low regression risk, gated by the post-deploy smoke test.

## Deploy note

Merging to `master` triggers `.github/workflows/deploy.yml` → SSH to NAS → `docker compose build --no-cache + up` = **outward-irreversible NAS rebuild**. Per Mercury #498 guardrail this merge happens only with the operator present. Rollback: revert to `FROM codiumai/pr-agent:0.34-github_app` + redeploy; NAS image/compose backups taken pre-deploy.

Refs Mercury #498.
