### PR TITLE
test(#498): smoke-test — Argus review on pragent 0.38.0 base (DO NOT MERGE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ logs/
 
 # pr-flow skill working files (PR-monitoring scratch state)
 .pr-flow-*
+
+# Python bytecode
+*.pyc

--- a/smoke_test_498.py
+++ b/smoke_test_498.py
@@ -1,0 +1,24 @@
+"""Throwaway smoke-test module for Mercury #498 rebase verification.
+
+This file exists ONLY to give Argus a small reviewable surface after the
+pragent/pr-agent:0.38.0 base rebase. It is deleted with the test PR and never
+merged to master.
+"""
+
+
+def parse_ids(items=[]):
+    """Parse a list of stringy ids into ints, skipping bad ones."""
+    result = []
+    for i in items:
+        try:
+            result.append(int(i))
+        except:
+            pass
+    return result
+
+
+def summarize(ids):
+    total = 0
+    for x in ids:
+        total = total + x
+    return total


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — throwaway smoke-test PR

This PR exists only to verify that Argus continues to review pull requests correctly after the Mercury #498 base-image rebase (`codiumai/pr-agent:0.34` which actually shipped 0.32-era code → digest-pinned `pragent/pr-agent:0.38.0-github_app`). It will be closed and its branch deleted as soon as Argus posts a review. Nothing here is intended to land on `master`.

### What this PR is probing

The single highest-risk axis of the rebase is the LLM routing path. The previously-deployed container ran litellm 1.81.12; the 0.38.0 base pins litellm 1.84.0. Argus routes every model call through pr-agent's `LiteLLMAIHandler`, and the primary review model is configured as `azure/responses/gpt-5.3-codex`, which exercises litellm's Azure Responses API path — exactly the code path most sensitive to a litellm minor-version bump. If the routing regressed, `/review` would fail to generate and Argus would either post an error or silently stop reviewing. A successful review posted on this PR is therefore the acceptance signal that the litellm 1.81.12 → 1.84.0 bump did not disturb Azure-Responses routing.

### Secondary things this PR exercises

The diff deliberately includes a change to `.gitignore`. Historically (Mercury #476 false-positive class A) the `bad_extensions.default` list in upstream pr-agent contained `gitignore`, which caused `.gitignore` hunks to be dropped from the review context and produced spurious "you changed a file we can't see" style findings. Argus carries a fork patch that re-includes such footer-dropped extensions. Including a `.gitignore` edit here confirms that patch still fires on the 0.38.0 base (the upstream `bad_extensions` list was verified unchanged at v0.38.0, so the fork patch remains necessary and should still apply cleanly).

The `smoke_test_498.py` module carries a couple of intentionally reviewable patterns (a mutable default argument and a bare `except:` clause) so that, if Argus's inline-thread generation is working, it has something concrete to comment on. This lets us confirm the `/improve` inline-suggestion path and the review-body capture path (both monkey-patched by Argus and both touched conceptually by the #498 coupling-point audit) are intact on the new base.

### Why the trailing reference matters for this test

This description is deliberately long. Mercury #476 false-positive class C was caused by `max_description_tokens` defaulting to 500, which head-clipped long PR bodies and dropped trailing `Closes`/`Fixes`/`Resolves`/`Refs #N` keywords before they reached the review prompt's `{{description}}` slot — making the ticket-compliance rule fire a false "missing issue reference" finding. Argus overrides `max_description_tokens` to 3000. If that override is live on the rebuilt container, the reference at the very end of this body should survive the clip and reach the review prompt, and Argus should NOT complain that this PR lacks an issue reference. If it does complain, the config drift-repair commit did not take effect on deploy.

Refs #498
